### PR TITLE
Calibration inherits ofNode. Also findBoard is a seperate function for ex

### DIFF
--- a/src/Calibration.cpp
+++ b/src/Calibration.cpp
@@ -155,7 +155,6 @@ namespace ofxCv {
 		int calibFlags = 0;
     float rms = calibrateCamera(objectPoints, imagePoints, addedImageSize, cameraMatrix, distCoeffs, boardRotations, boardTranslations, calibFlags);
     ofLog(OF_LOG_VERBOSE, "calibrateCamera() reports RMS error of " + ofToString(rms));
-		cout << "should be printing..." << endl;
 		
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);
 		
@@ -257,7 +256,7 @@ namespace ofxCv {
 	int Calibration::size() const {
 		return imagePoints.size();
 	}
-	void Calibration::customDraw() const {
+	void Calibration::customDraw() {
 		for(int i = 0; i < size(); i++) {
 			draw(i);
 		}

--- a/src/Calibration.h
+++ b/src/Calibration.h
@@ -79,11 +79,7 @@ namespace ofxCv {
 		
 		int size() const;
 		
-		void customDraw() {
-			ofBox(10);
-			ofDrawAxis(20);
-		}
-		void customDraw() const;
+		void customDraw();
 		void draw(int i) const;
 		void draw3d() const;
 		void draw3d(int i) const;


### PR DESCRIPTION
Calibration inherits ofNode for more general 3D use (+compatability with scrDraw3D in ofxCvGUI).
Also keeps existing usage

Also findBoard is a seperate function for external access.

kept terse style consistent (i believe).
