### PR TITLE
make imagePoints public

### DIFF
--- a/src/Calibration.h
+++ b/src/Calibration.h
@@ -85,8 +85,9 @@ namespace ofxCv {
 		
 		const bool &isReady;
 		
-	protected:
 		vector<vector<Point2f> > imagePoints;
+		
+	protected:
 		cv::Size boardSize, addedImageSize;
 		float squareSize;
 		Mat grayMat;


### PR DESCRIPTION
make imagePoints public. very useful for lots of cases where your app wants to render / manipulate (e.g. undo, count) the points we have found during calibration

no brainer really
