### PR TITLE
Flow: add calls to create pyramids conditionally for cv >2.4.1

### DIFF
--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -83,6 +83,7 @@ namespace ofxCv {
 		
 		void drawFlow(ofRectangle r);
 		void calcFlow();
+		void calcFeaturesToTrack(vector<cv::Point2f> & features);
 		
 		vector<cv::Point2f> prevPts, nextPts;
 		
@@ -97,6 +98,8 @@ namespace ofxCv {
 
 		//pyramid levels
 		int pyramidLevels;
+
+		bool calcFeaturesNextFrame;
 
 		//pyramid + err/status data
 		vector<cv::Mat> pyramid;


### PR DESCRIPTION
seems like pre 2.4.1 there wasn't the possibility of passing pyramids to that function so i've just put some ifdefs. 

this also fixes a problem with how the features where being reseted
