### PR TITLE
Adding ability to compare previous/current states from a custom MyFollower class

### DIFF
--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -308,10 +308,13 @@ namespace ofxCv {
 	protected:
 		bool dead;
 		unsigned int label;
+         T previous;
 	public:
 		Follower()
 		:dead(false)
-		,label(0) {}
+		,label(0)
+        ,previous(T())
+        {};
 		
 		virtual ~Follower(){};
 		virtual void setup(const T& track) {}
@@ -329,7 +332,12 @@ namespace ofxCv {
 		bool getDead() const {
 			return dead;
 		}
+        void setPrevious(const T& previous){
+            this->previous = previous;
+        }
 	};
+            
+            
 	
 	typedef Follower<cv::Rect> RectFollower;
 	typedef Follower<cv::Point2f> PointFollower;
@@ -338,18 +346,21 @@ namespace ofxCv {
 	class TrackerFollower : public Tracker<T> {
 	protected:
 		vector<unsigned int> labels;
-		vector<F> followers;
+        vector<F> followers;
 	public:
+
 		vector<unsigned int>& track(const vector<T>& objects) {
 			Tracker<T>::track(objects);
 			// kill missing, update old
 			for(int i = 0; i < labels.size(); i++) {
 				unsigned int curLabel = labels[i];
 				F& curFollower = followers[i];
+                
 				if(!Tracker<T>::existsCurrent(curLabel)) {
 					curFollower.kill();
 				} else {
 					curFollower.update(Tracker<T>::getCurrent(curLabel));
+                    curFollower.setPrevious(Tracker<T>::getPrevious(curLabel));   
 				}
 			}
 			// add new


### PR DESCRIPTION
Hey Kyle,

I'm new to your lib so excuse me if I didn't do this right…I followed your instructions at the top of Tracker.h to create my own custom MyFollower class.  My application requires that I kill off followers that don't meet a minimum velocity.  After a lot of trial and error, the only way I could figure out how to do was by storing the previous instance of the follower as a protected member of Follower and then having it update whenever tracker.track() is called.

If there's an easier/better way to do this then obviously please ignore (though I would be curious to know), otherwise maybe this could be of use to others.

Thanks for the lib!
Eric
