### PR TITLE
Updated all example main.cpp files to use default window, rather than forcing ofAppGlutWindow.

### DIFF
--- a/example-ar/src/main.cpp
+++ b/example-ar/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-background/src/main.cpp
+++ b/example-background/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-bayer/src/main.cpp
+++ b/example-bayer/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-calibration/src/main.cpp
+++ b/example-calibration/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-coherent-lines/src/main.cpp
+++ b/example-coherent-lines/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 1280, 720, OF_WINDOW);
+	ofSetupOpenGL(1280, 720, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-advanced/src/main.cpp
+++ b/example-contours-advanced/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-basic/src/main.cpp
+++ b/example-contours-basic/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-color/src/main.cpp
+++ b/example-contours-color/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-following/src/main.cpp
+++ b/example-contours-following/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 320, 240, OF_WINDOW);
+	ofSetupOpenGL(320, 240, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-quad/src/main.cpp
+++ b/example-contours-quad/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-contours-tracking/src/main.cpp
+++ b/example-contours-tracking/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 320, 240, OF_WINDOW);
+	ofSetupOpenGL(320, 240, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-difference-columns/src/main.cpp
+++ b/example-difference-columns/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 320 * 2, 240, OF_WINDOW);
+	ofSetupOpenGL(320 * 2, 240, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-difference/src/main.cpp
+++ b/example-difference/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 320 * 2, 240, OF_WINDOW);
+	ofSetupOpenGL(320 * 2, 240, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-edge/src/main.cpp
+++ b/example-edge/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-empty/src/main.cpp
+++ b/example-empty/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-estimate-affine/src/main.cpp
+++ b/example-estimate-affine/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-face-follow/src/main.cpp
+++ b/example-face-follow/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-face-zoom/src/main.cpp
+++ b/example-face-zoom/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 512, 512, OF_WINDOW);
+	ofSetupOpenGL(512, 512, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-face/src/main.cpp
+++ b/example-face/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-flow-distort/src/main.cpp
+++ b/example-flow-distort/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640, 480, OF_WINDOW);
+	ofSetupOpenGL(640, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-flow-keypoints/src/main.cpp
+++ b/example-flow-keypoints/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-flow/src/main.cpp
+++ b/example-flow/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main(){
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 1024, 768, OF_WINDOW);
+	ofSetupOpenGL(1024, 768, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-gesture/src/main.cpp
+++ b/example-gesture/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 1280, 720, OF_FULLSCREEN);
+	ofSetupOpenGL(1280, 720, OF_FULLSCREEN);
 	ofRunApp(new testApp());
 }

--- a/example-homography/src/main.cpp
+++ b/example-homography/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-kalman/src/main.cpp
+++ b/example-kalman/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-threshold/src/main.cpp
+++ b/example-threshold/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }

--- a/example-undistortion/src/main.cpp
+++ b/example-undistortion/src/main.cpp
@@ -1,8 +1,6 @@
 #include "testApp.h"
-#include "ofAppGlutWindow.h"
 
 int main() {
-	ofAppGlutWindow window;
-	ofSetupOpenGL(&window, 640 * 2, 480, OF_WINDOW);
+	ofSetupOpenGL(640 * 2, 480, OF_WINDOW);
 	ofRunApp(new testApp());
 }


### PR DESCRIPTION
In 0.8.0 all examples will be using this format (it's coming from the RPI branch).  Since RPI and other platforms have no GLUT window, let the `ofSetupOpenGL` method figure out the best window for the system.
