### PR TITLE
added resetFlow() , fixed NaN for switching videos by selectively applyi...

### DIFF
--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -31,7 +31,8 @@ namespace ofxCv {
 		void draw(ofRectangle rect);
 		int  getWidth();
 		int  getHeight();
-		
+        //specific reset implementation
+        virtual void resetFlow() = 0;
 	protected:
 		ofImage last, curr;
 		bool hasFlow;
@@ -78,7 +79,7 @@ namespace ofxCv {
 		void resetFeaturesToTrack();
 		void setFeaturesToTrack(const vector<ofVec2f> & features);
 		void setFeaturesToTrack(const vector<cv::Point2f> & features);
-		
+        void resetFlow();
 	protected:
 		
 		void drawFlow(ofRectangle r);

--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -71,7 +71,7 @@ namespace ofxCv {
 	int Flow::getWidth()  { return 0; }
 	int Flow::getHeight() { return 0; }
 	
-	
+    
 #pragma mark PYRLK IMPLEMENTATION
 	FlowPyrLK::FlowPyrLK()
 	:windowSize(32)
@@ -112,7 +112,7 @@ namespace ofxCv {
 				prevPts = nextPts;
 			}
 			nextPts.clear();
-			
+
 #if CV_MAJOR_VERSION>=2 && (CV_MINOR_VERSION>4 || (CV_MINOR_VERSION==4 && CV_SUBMINOR_VERSION>=1))
 			buildOpticalFlowPyramid(toCv(curr),pyramid,cv::Size(windowSize, windowSize),10);
 			calcOpticalFlowPyrLK(
@@ -214,6 +214,13 @@ namespace ofxCv {
 			}
 		}
 	}
+    
+    void FlowPyrLK::resetFlow(){
+        hasFlow = false;
+        last.clear();
+        resetFeaturesToTrack();
+        prevPts.clear();
+    }
 	
 #pragma mark FARNEBACK IMPLEMENTATION
 	FlowFarneback::FlowFarneback()


### PR DESCRIPTION
We found an error when switching videos where if the initial flow flag was set it would mess up the calculation so added resetFlow() to prevent that issue. And added checks for hasFlow in getFlowOffset() and getFlowPosition()
