### PR TITLE
overloaded Intrinsics::loadProjectionMatrix with viewportRect argument

### DIFF
--- a/libs/ofxCv/include/ofxCv/Calibration.h
+++ b/libs/ofxCv/include/ofxCv/Calibration.h
@@ -37,8 +37,7 @@ namespace ofxCv {
 		double getFocalLength() const;
 		double getAspectRatio() const;
 		Point2d getPrincipalPoint() const;
-		void loadProjectionMatrix(float nearDist = 10., float farDist = 10000.) const;
-		void loadProjectionMatrix(ofRectangle viewportRect, float nearDist = 10., float farDist = 10000.) const;
+		void loadProjectionMatrix(float nearDist = 10., float farDist = 10000., cv::Point2d viewportOffset = cv::Point2d(0, 0)) const;
 	protected:
 		Mat cameraMatrix;
 		cv::Size imageSize, sensorSize;

--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -46,17 +46,13 @@ namespace ofxCv {
 	Point2d Intrinsics::getPrincipalPoint() const {
 		return principalPoint;
 	}
-
-	void Intrinsics::loadProjectionMatrix(float nearDist, float farDist) const {
-        loadProjectionMatrix(ofRectangle(0,0,imageSize.width, imageSize.height), nearDist, farDist);
-    }
     
-	void Intrinsics::loadProjectionMatrix(ofRectangle viewportRect, float nearDist, float farDist) const {
-		glViewport(viewportRect.x, viewportRect.y, viewportRect.width, viewportRect.height);
+	void Intrinsics::loadProjectionMatrix(float nearDist, float farDist, cv::Point2d viewportOffset) const {
+		glViewport(viewportOffset.x, viewportOffset.y, imageSize.width, imageSize.height);
 		glMatrixMode(GL_PROJECTION);
 		glLoadIdentity();
-		float w = viewportRect.width;
-		float h = viewportRect.height;
+		float w = imageSize.width;
+		float h = imageSize.height;
 		float fx = cameraMatrix.at<double>(0, 0);
 		float fy = cameraMatrix.at<double>(1, 1);
 		float cx = principalPoint.x;


### PR DESCRIPTION
In some cases (projection mapping, use of external display..etc) it can be useful to set the viewport coordinates and size. This PR just adds an overloaded method with the viewport as first argument.

EDIT :  in case of projection calibration, the imageSize is likely to be different from the camera input size used to detect the calibration pattern. So I also had to add a setter on Intrinsics::imagSize
