### PR TITLE
Fixes ofxCv::RectTracker::track() to erase from map directly with iterator and stop re-using iterator. 

### DIFF
--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -331,11 +331,13 @@ namespace ofxCv {
 					smoothed[label] = cur;
 				}
 			}
-			std::map<unsigned int, cv::Rect>::iterator smoothedItr;
-			for(smoothedItr = smoothed.begin(); smoothedItr != smoothed.end(); smoothedItr++) {
+			std::map<unsigned int, cv::Rect>::iterator smoothedItr = smoothed.begin();
+			while(smoothedItr != smoothed.end()) {
 				unsigned int label = smoothedItr->first;
 				if(!existsCurrent(label)) {
-					smoothed.erase(smoothed.find(label));
+					smoothedItr = smoothed.erase(smoothedItr);
+				} else {
+					++smoothedItr;
 				}
 			}
 			return labels;


### PR DESCRIPTION
Resolves #98
