### PR TITLE
This should fix issue #101 and #102 by post-incrementing the iterator passed into map::erase instead of using the return value.

### DIFF
--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -335,7 +335,7 @@ namespace ofxCv {
 			while(smoothedItr != smoothed.end()) {
 				unsigned int label = smoothedItr->first;
 				if(!existsCurrent(label)) {
-					smoothedItr = smoothed.erase(smoothedItr);
+					smoothed.erase(smoothedItr++);
 				} else {
 					++smoothedItr;
 				}


### PR DESCRIPTION
Sorry for not realizing that map::erase did not always return a value.  This shouldn't need ifdefs to solve and also, running find is logarithmic cost vs. directly erasing with the iterator is constant cost.
