### PR TITLE
FlowFarneback pyramidScale must be < 1

### DIFF
--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -238,7 +238,7 @@ namespace ofxCv {
 	}
 	
 	void FlowFarneback::setPyramidScale(float scale){
-		if(scale < 0.0 || scale > 1.0){
+		if(scale < 0.0 || scale >= 1.0){
 			ofLogWarning("ofxCvFlowFarneback -- Warning setting scale to a number outside of 0 - 1");
 		}
 		this->pyramidScale = scale;


### PR DESCRIPTION
Since it causes a crash, it might be worth it to set it to 0.99 if it's >= 1.

courtesy: 1 character pull request guy
