### PR TITLE
ContourFinder sorts contours by size; can return a fixed number

### DIFF
--- a/libs/ofxCv/include/ofxCv/ContourFinder.h
+++ b/libs/ofxCv/include/ofxCv/ContourFinder.h
@@ -75,6 +75,7 @@ namespace ofxCv {
 		void setInvert(bool invert);
 		void setTargetColor(ofColor targetColor, TrackingColorMode trackingColorMode = TRACK_COLOR_RGB);
 		void setFindHoles(bool findHoles);
+		void setSortBySize(bool sortBySize);
 		
 		void resetMinArea();
 		void resetMaxArea();
@@ -88,7 +89,7 @@ namespace ofxCv {
 		void setSimplify(bool simplify);
 		
 		void draw();
-		
+
 	protected:
 		cv::Mat hsvBuffer, thresh;
 		bool autoThreshold, invert, simplify;
@@ -108,6 +109,7 @@ namespace ofxCv {
 		vector<cv::Rect> boundingRects;
 
 		int contourFindingMode;
+		bool sortBySize;
 	};	
 	
 }


### PR DESCRIPTION
This is to solve issue kylemcdonald/ofxCv#110 (**Ability to sort ContourFinder results by area**).
- New method `setMaxContours()` allows you to specify the maximum
  number of contours to return.  Since they are now sorted by area,
  this means you will get the _N_ largest contours.
- A value less
  than 1 for `maxContours` means that you'll get all contours (same default behaviour
  as before).
