### PR TITLE
ObjectFinder using grayscale images as source

### DIFF
--- a/libs/ofxCv/include/ofxCv/ObjectFinder.h
+++ b/libs/ofxCv/include/ofxCv/ObjectFinder.h
@@ -34,8 +34,7 @@ namespace ofxCv {
 			update(toCv(img));
 		}
 		void update(cv::Mat img);
-		void updateGray(cv::Mat img);
-		unsigned int size() const;
+        unsigned int size() const;
 		ofRectangle getObject(unsigned int i) const;
 		ofRectangle getObjectSmoothed(unsigned int i) const;
 		RectTracker& getTracker();

--- a/libs/ofxCv/src/ObjectFinder.cpp
+++ b/libs/ofxCv/src/ObjectFinder.cpp
@@ -21,11 +21,10 @@ namespace ofxCv {
 		}
 	}
 	void ObjectFinder::update(cv::Mat img) {
-		convertColor(img, gray, CV_RGB2GRAY);
-		updateGray(gray);
-	}
-	void ObjectFinder::updateGray(cv::Mat gray) {
-		resize(gray, graySmall, rescale, rescale);
+        cv::Mat gray;
+        if(getChannels(img) == 1) gray = img;
+        else                      copyGray(img,gray);
+        resize(gray, graySmall, rescale, rescale);
 		cv::Mat graySmallMat = toCv(graySmall);
 		if(useHistogramEqualization) {
 			equalizeHist(graySmallMat, graySmallMat);


### PR DESCRIPTION
Sometimes images to be analyzed by the ObjectFinder might already be grayscale (for example in the situation of fetching the Y channel of an YUV stream like the Raspberry PI camera) and the detection should still work. Currently the ObjectFinder always assumes the image to be analyzed is color and it should also allow grayscale images as an input. I hope the quick and dirty tweak I added will be acceptable, otherwise please suggest other options that would fit this situation better.
