### PR TITLE
Refactor loadProjectionMatrix() to use OF matrix functions instead of gl

### DIFF
--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -48,9 +48,9 @@ namespace ofxCv {
 	}
     
 	void Intrinsics::loadProjectionMatrix(float nearDist, float farDist, cv::Point2d viewportOffset) const {
-		glViewport(viewportOffset.x, viewportOffset.y, imageSize.width, imageSize.height);
-		glMatrixMode(GL_PROJECTION);
-		glLoadIdentity();
+		ofViewport(viewportOffset.x, viewportOffset.y, imageSize.width, imageSize.height);
+		ofSetMatrixMode(OF_MATRIX_PROJECTION);
+		ofLoadIdentityMatrix();
 		float w = imageSize.width;
 		float h = imageSize.height;
 		float fx = cameraMatrix.at<double>(0, 0);
@@ -58,27 +58,19 @@ namespace ofxCv {
 		float cx = principalPoint.x;
 		float cy = principalPoint.y;
 		
-// Macro required for OpenGLES as it using different function name for frustrum
-#ifdef TARGET_OPENGLES
-		glFrustumf(
-#else
-		glFrustum(
-#endif
+		ofMatrix4x4 frustum;
+		frustum.makeFrustumMatrix(
 			nearDist * (-cx) / fx, nearDist * (w - cx) / fx,
-			nearDist * (cy - h) / fy, nearDist * (cy) / fy,
+			nearDist * (cy) / fy, nearDist * (cy - h) / fy,
 			nearDist, farDist);
-		glMatrixMode(GL_MODELVIEW);
-		glLoadIdentity();
-#ifdef TARGET_OPENGLES
+		ofMultMatrix(frustum);
+
+		ofSetMatrixMode(OF_MATRIX_MODELVIEW);
+		ofLoadIdentityMatrix();
+
 		ofMatrix4x4 lookAt;
-		lookAt.makeLookAtMatrix(ofVec3f(0,0,0), ofVec3f(0,0,1), ofVec3f(0,-1,0));
-		glMultMatrixf(lookAt.getPtr());
-#else
-		gluLookAt(
-			0, 0, 0,
-			0, 0, 1,
-			0, -1, 0);
-#endif
+		lookAt.makeLookAtViewMatrix(ofVec3f(0,0,0), ofVec3f(0,0,1), ofVec3f(0,-1,0));
+		ofMultMatrix(lookAt);
 	}
 	
 	Calibration::Calibration() :


### PR DESCRIPTION
This patch changes the loadProjectionMatrix() method to use OF matrix functions instead of the underlying gl variants. This change is especially important when using the glprogrammablerenderer, which does not natively have (modelview/projection) matrix stacks. The ofMatrixStack was added to OF to work around this, but it is defeated if an app mixes OF and gl matrix functions.

One important sideeffect of using the OF functions is that gl assumes bottom-up coordinates and OF assumes top-down coordinates. See the discussion here:
http://forum.openframeworks.cc/t/why-is-ofmatrixstack-vflipped-by-default/16088
In this patch, I am creating the frustum matrix upsidedown to work around this change. This seems to work for me, but I am not sure how this influences the handedness of the projection and if this change affects backface-culling. This should be tested (by someone who understands this stuff)!

This patch also fixes a bug introduced in https://github.com/kylemcdonald/ofxCv/pull/105 which created the wrong lookatMatrix.
