### PR TITLE
Kalman filter: add acceleration variables for smoother velocity

### DIFF
--- a/libs/ofxCv/include/ofxCv/Kalman.h
+++ b/libs/ofxCv/include/ofxCv/Kalman.h
@@ -12,7 +12,9 @@ namespace ofxCv {
 		KalmanFilter KF;
 		Mat_<T> measurement, prediction, estimated;
 	public:
-		void init(T smoothness = 0.1, T rapidness = 0.1); // smaller is more smooth/rapid
+		// smoothness, rapidness: smaller is more smooth/rapid
+		// bUseAccel: set true to smooth out velocity
+		void init(T smoothness = 0.1, T rapidness = 0.1, bool bUseAccel = false);
 		void update(const ofVec3f&);
 		ofVec3f getPrediction();
 		ofVec3f getEstimation();
@@ -26,7 +28,7 @@ namespace ofxCv {
 	class KalmanEuler_ : public KalmanPosition_<T> {
 		ofVec3f eulerPrev; // used for finding appropriate dimension
 	public:
-		void init(T smoothness = 0.1, T rapidness = 0.1); // smaller is more smooth/rapid
+		void init(T smoothness = 0.1, T rapidness = 0.1, bool bUseAccel = false);
 		void update(const ofQuaternion&);
 		ofQuaternion getPrediction();
 		ofQuaternion getEstimation();

--- a/libs/ofxCv/src/Kalman.cpp
+++ b/libs/ofxCv/src/Kalman.cpp
@@ -8,21 +8,39 @@ namespace ofxCv {
 	using namespace cv;
 	
 	template <class T>
-	void KalmanPosition_<T>::init(T smoothness, T rapidness) {
-		KF.init(6, 3, 0); // 6 variables (position+velocity) and 3 measurements (position)
-		
-		KF.transitionMatrix = *(Mat_<T>(6, 6) <<
-								1,0,0,1,0,0,
-								0,1,0,0,1,0,
-								0,0,1,0,0,1,
-								0,0,0,1,0,0,
-								0,0,0,0,1,0,
-								0,0,0,0,0,1);
-		
-		measurement = Mat_<T>::zeros(3, 1);
-		
-		KF.statePre = Mat_<T>::zeros(6, 1);
-		
+	void KalmanPosition_<T>::init(T smoothness, T rapidness, bool bUseAccel) {
+		if( bUseAccel ) {
+			KF.init(9, 3, 0); // 9 variables (position+velocity+accel) and 3 measurements (position)
+			
+			KF.transitionMatrix = *(Mat_<T>(9, 9) <<
+									1,0,0,1,0,0,0.5,0,0,
+									0,1,0,0,1,0,0,0.5,0,
+									0,0,1,0,0,1,0,0,0.5,
+									0,0,0,1,0,0,1,0,0,
+									0,0,0,0,1,0,0,1,0,
+									0,0,0,0,0,1,0,0,1,
+									0,0,0,0,0,0,1,0,0,
+									0,0,0,0,0,0,0,1,0,
+									0,0,0,0,0,0,0,0,1);
+			
+			measurement = Mat_<T>::zeros(3, 1);
+			
+			KF.statePre = Mat_<T>::zeros(9, 1);
+		} else {
+			KF.init(6, 3, 0); // 6 variables (position+velocity) and 3 measurements (position)
+			
+			KF.transitionMatrix = *(Mat_<T>(6, 6) <<
+									1,0,0,1,0,0,
+									0,1,0,0,1,0,
+									0,0,1,0,0,1,
+									0,0,0,1,0,0,
+									0,0,0,0,1,0,
+									0,0,0,0,0,1);
+			
+			measurement = Mat_<T>::zeros(3, 1);
+			
+			KF.statePre = Mat_<T>::zeros(6, 1);
+		}
 		setIdentity(KF.measurementMatrix);
 		setIdentity(KF.processNoiseCov, Scalar::all(smoothness));
 		setIdentity(KF.measurementNoiseCov, Scalar::all(rapidness));
@@ -62,8 +80,8 @@ namespace ofxCv {
 	template class KalmanPosition_<float>;
 	
 	template <class T>
-	void KalmanEuler_<T>::init(T smoothness, T rapidness) {
-		KalmanPosition_<T>::init(smoothness, rapidness);
+	void KalmanEuler_<T>::init(T smoothness, T rapidness, bool bUseAccel) {
+		KalmanPosition_<T>::init(smoothness, rapidness, bUseAccel);
 		eulerPrev.x = 0.f;
 		eulerPrev.y = 0.f;
 		eulerPrev.z = 0.f;


### PR DESCRIPTION
Hi, I'm tweaking the Kalman filter API I implemented and noticed sometimes useful to take acceleration variables into account so that velocity variables (which can be acquired by `getVelocity()`) become smoother. I added `bool bUseAccel = false` argument into `init(...)` which is backward compatible.
