### PR TITLE
add getNormalizedAverageFlow

### DIFF
--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -137,7 +137,10 @@ namespace ofxCv {
 		ofVec2f getFlowPosition(int x, int y);
 		ofVec2f getTotalFlowInRegion(ofRectangle region);
 		ofVec2f getAverageFlowInRegion(ofRectangle region);
-		
+
+        float getNormalizedAverageFlow();
+        void setFlowAvgMinCalibrationRate(float r);
+        void setFlowAvgMaxCalibrationRate(float r);
         //call this if you switch to a new video file to reset internal caches
         void resetFlow();
     
@@ -154,6 +157,11 @@ namespace ofxCv {
 		int polyN;
 		float polySigma;
 		bool farnebackGaussian;
+
+        float flowAvgPrev;
+        float flowMinCalibrationRate, flowMaxCalibrationRate;
+        float flowAvgMin, flowAvgMax;
+
 	};
 	
 }

--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -213,6 +213,11 @@ namespace ofxCv {
 	,polyN(7)
 	,polySigma(1.5)
 	,farnebackGaussian(false)
+    ,flowAvgPrev(0.f)
+    ,flowMinCalibrationRate(0.0005)
+    ,flowMaxCalibrationRate(0.0005)
+    ,flowAvgMin(0.f)
+    ,flowAvgMax(1.f)
 	{
 	}
 	
@@ -296,7 +301,6 @@ namespace ofxCv {
 	ofVec2f FlowFarneback::getAverageFlow(){
 		return getAverageFlowInRegion(ofRectangle(0,0,flow.cols,flow.rows));
 	}
-	
 	ofVec2f FlowFarneback::getAverageFlowInRegion(ofRectangle rect){
 		return getTotalFlowInRegion(rect)/(rect.width*rect.height);
 	}
@@ -309,7 +313,40 @@ namespace ofxCv {
 		const Scalar& sc = sum(flow(toCv(region)));
 		return ofVec2f(sc[0], sc[1]);
 	}
-	
+
+    float FlowFarneback::getNormalizedAverageFlow(){
+        // update flow
+        ofVec2f avg = getAverageFlow();
+        float mean = abs(avg.x) + abs(avg.y) / 2;
+
+        // normalise to 0.0-1.0
+        mean = ofMap(mean, flowAvgMin, flowAvgMax, 0.f, 1.f, true);
+
+        // update min/max
+        flowAvgMin = fmin(mean, flowAvgMin);
+        flowAvgMax = fmax(mean, flowAvgMax);
+
+        // calibrate: constantly reduce the max and increase the min to account
+        // for any tiny/huge anomolies
+        flowAvgMin += flowMinCalibrationRate;
+        flowAvgMax -= flowMaxCalibrationRate;
+
+        // smooth by averaging with previous value
+         mean = (mean + flowAvgPrev) / 2;
+        // store value for next time
+        flowAvgPrev = mean;
+
+        return mean;
+    }
+
+    void FlowFarneback::setFlowAvgMinCalibrationRate(float r){
+        flowMinCalibrationRate = r;
+    }
+
+    void FlowFarneback::setFlowAvgMaxCalibrationRate(float r){
+        flowMaxCalibrationRate = r;
+    }
+
 	void FlowFarneback::drawFlow(ofRectangle rect){
 		if(!hasFlow){
 			return;


### PR DESCRIPTION
returns a float between 0.0 and 1.0 that represents the average flow

I found this to be a really useful method for controlling other parameters, and that it lived better here than in an external class.
It calibrates itself by incrementing/decrementing the running min and max values by a particular rate, which can be altered.
