### PR TITLE
fixed narrowing compile error on osx/linux

### DIFF
--- a/libs/ofxCv/include/ofxCv/Wrappers.h
+++ b/libs/ofxCv/include/ofxCv/Wrappers.h
@@ -379,7 +379,7 @@ cv::name(xMat, yMat, resultMat);\
 	void fillPoly(vector<cv::Point>& points, D& dst) {
 		cv::Mat dstMat = toCv(dst);
 		const cv::Point* ppt[1] = { &(points[0]) };
-		int npt[] = { points.size() };
+		int npt[] = { static_cast<int>(points.size()) };
 		dstMat.setTo(Scalar(0));
 		fillPoly(dstMat, ppt, npt, 1, Scalar(255));
 	}


### PR DESCRIPTION
This fixes a compile bug on osx/linux. I did what clang said:
````
/Users/felix/Source/of/addons/ofxCv/libs/ofxCv/include/ofxCv/Wrappers.h:382:17: error: non-constant-expression cannot be narrowed from type 'size_type' (aka 'unsigned long') to
      'int' in initializer list [-Wc++11-narrowing]
                int npt[] = { points.size() };
                              ^~~~~~~~~~~~~
/Users/felix/Source/of/addons/ofxCv/libs/ofxCv/include/ofxCv/Wrappers.h:382:17: note: insert an explicit cast to silence this issue
                int npt[] = { points.size() };
                              ^~~~~~~~~~~~~
                              static_cast<int>( )
````
