### PR TITLE
remove errors, fail faster, save nanoseconds.

### DIFF
--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -168,23 +168,27 @@ namespace ofxCv {
 	// allocation
 	// only happens when necessary
 	template <class T> inline void allocate(T& img, int width, int height, int cvType) {
-		int iw = getWidth(img), ih = getHeight(img);
-		int it = getCvImageType(img);
-		if(iw != width || ih != height || it != cvType) {
-			img.allocate(width, height, getOfImageType(cvType));
-		}
+        if (!img.isAllocated() ||
+            getWidth(img) != width ||
+            getHeight(img) != height ||
+            getCvImageType(img) != cvType)
+        {
+            img.allocate(width, height, getOfImageType(cvType));
+        }
 	}
     inline void allocate(ofTexture& img, int width, int height, int cvType) {
-        int iw = getWidth(img), ih = getHeight(img);
-        int it = getCvImageType(img);
-        if(iw != width || ih != height || it != cvType) {
+        if (!img.isAllocated() ||
+            getWidth(img) != width ||
+            getHeight(img) != height ||
+            getCvImageType(img) != cvType)
+        {
             img.allocate(width, height, getGlImageType(cvType));
         }
     }
 	inline void allocate(Mat& img, int width, int height, int cvType) {
-		int iw = getWidth(img), ih = getHeight(img);
-		int it = getCvImageType(img);
-		if(iw != width || ih != height || it != cvType) {
+        if (getWidth(img) != width ||
+            getHeight(img) != height ||
+            getCvImageType(img) != cvType) {
 			img.create(height, width, cvType);
 		}
 	}


### PR DESCRIPTION
When calling imitate using unallocated ofImages (or ofPixels, etc) an error such as:

`[ error ] ofPixels: Format doesn't support channels`

is seen repeatedly.  This happens because imitate tries to query the unallocated ofPixels about its channel count, and when unallocated, ofPixels is set to an unknown format, which results in the error.

This can be avoided by checking to see if the ofImage/ofPixel/ofTexture types are allocated before checking all of the secondary info, width, height, type, etc.

In addition to getting rid of the errors (see `example-calibration` for instance), this should, theoretically this shave off a few nanoseconds too. :)
