### PR TITLE
Replace functions deprecated in 0.9.0.

### DIFF
--- a/example-bayer/src/ofApp.cpp
+++ b/example-bayer/src/ofApp.cpp
@@ -6,8 +6,8 @@ using namespace cv;
 void ofApp::setup() {
 	ofSetVerticalSync(true);
 
-	bayer.loadImage("bayer.png");
-	rgb.loadImage("rgb.png");
+	bayer.load("bayer.png");
+	rgb.load("rgb.png");
 	
 	bayerType = 0;
 }

--- a/example-contours-advanced/src/ofApp.cpp
+++ b/example-contours-advanced/src/ofApp.cpp
@@ -43,14 +43,14 @@ void ofApp::draw() {
 		ofVec2f ellipseSize = toOf(ellipse.size);
 		ofTranslate(ellipseCenter.x, ellipseCenter.y);
 		ofRotate(ellipse.angle);
-		ofEllipse(0, 0, ellipseSize.x, ellipseSize.y);
+		ofDrawEllipse(0, 0, ellipseSize.x, ellipseSize.y);
 		ofPopMatrix();
 		
 		// minimum area circle that encloses the contour
 		ofSetColor(cyanPrint);
 		float circleRadius;
 		ofVec2f circleCenter = toOf(contourFinder.getMinEnclosingCircle(i, circleRadius));
-		ofCircle(circleCenter, circleRadius);
+		ofDrawCircle(circleCenter, circleRadius);
 		
 		// convex hull of the contour
 		ofSetColor(yellowPrint);
@@ -60,7 +60,7 @@ void ofApp::draw() {
 		// defects of the convex hull
 		vector<cv::Vec4i> defects = contourFinder.getConvexityDefects(i);
 		for(int j = 0; j < defects.size(); j++) {
-			ofLine(defects[j][0], defects[j][1], defects[j][2], defects[j][3]);
+			ofDrawLine(defects[j][0], defects[j][1], defects[j][2], defects[j][3]);
 		}
 		
 		// some different styles of contour centers
@@ -68,11 +68,11 @@ void ofApp::draw() {
 		ofVec2f average = toOf(contourFinder.getAverage(i));
 		ofVec2f center = toOf(contourFinder.getCenter(i));
 		ofSetColor(cyanPrint);
-		ofCircle(centroid, 1);
+		ofDrawCircle(centroid, 1);
 		ofSetColor(magentaPrint);
-		ofCircle(average, 1);
+		ofDrawCircle(average, 1);
 		ofSetColor(yellowPrint);
-		ofCircle(center, 1);
+		ofDrawCircle(center, 1);
 		
 		// you can also get the area and perimeter using ofPolyline:
 		// ofPolyline::getArea() and ofPolyline::getPerimeter()
@@ -86,7 +86,7 @@ void ofApp::draw() {
 		ofPushMatrix();
 		ofTranslate(centroid.x, centroid.y);
 		ofScale(5, 5);
-		ofLine(0, 0, balance.x, balance.y);
+		ofDrawLine(0, 0, balance.x, balance.y);
 		ofPopMatrix();
 	}
 
@@ -98,13 +98,13 @@ void ofApp::draw() {
 	ofTranslate(8, 75);
 	ofFill();
 	ofSetColor(0);
-	ofRect(-3, -3, 64+6, 64+6);
+	ofDrawRectangle(-3, -3, 64+6, 64+6);
 	ofSetColor(targetColor);
-	ofRect(0, 0, 64, 64);
+	ofDrawRectangle(0, 0, 64, 64);
 }
 
 void ofApp::mousePressed(int x, int y, int button) {
-	targetColor = cam.getPixelsRef().getColor(x, y);
+	targetColor = cam.getPixels().getColor(x, y);
 	contourFinder.setTargetColor(targetColor, trackingColorMode);
 }
 

--- a/example-contours-following/src/ofApp.cpp
+++ b/example-contours-following/src/ofApp.cpp
@@ -35,7 +35,7 @@ void Glow::draw() {
 		size = ofMap(ofGetElapsedTimef() - startedDying, 0, dyingTime, size, 0, true);
 	}
 	ofNoFill();
-	ofCircle(cur, size);
+	ofDrawCircle(cur, size);
 	ofSetColor(color);
 	all.draw();
 	ofSetColor(255);
@@ -47,7 +47,7 @@ void ofApp::setup() {
 	ofSetVerticalSync(true);
 	ofBackground(0);
 	
-	movie.loadMovie("video.mov");
+	movie.load("video.mov");
 	movie.play();
 	
 	contourFinder.setMinAreaRadius(1);

--- a/example-contours-tracking/src/ofApp.cpp
+++ b/example-contours-tracking/src/ofApp.cpp
@@ -7,7 +7,7 @@ void ofApp::setup() {
 	ofSetVerticalSync(true);
 	ofBackground(0);
 	
-	movie.loadMovie("video.mov");
+	movie.load("video.mov");
 	movie.play();
 	
 	contourFinder.setMinAreaRadius(1);
@@ -46,7 +46,7 @@ void ofApp::draw() {
 			ofDrawBitmapString(msg, 0, 0);
 			ofVec2f velocity = toOf(contourFinder.getVelocity(i));
 			ofScale(5, 5);
-			ofLine(0, 0, velocity.x, velocity.y);
+			ofDrawLine(0, 0, velocity.x, velocity.y);
 			ofPopMatrix();
 		}
 	} else {
@@ -63,7 +63,7 @@ void ofApp::draw() {
 				// get the centers of the rectangles
 				ofVec2f previousPosition(previous.x + previous.width / 2, previous.y + previous.height / 2);
 				ofVec2f currentPosition(current.x + current.width / 2, current.y + current.height / 2);
-				ofLine(previousPosition, currentPosition);
+				ofDrawLine(previousPosition, currentPosition);
 			}
 		}
 	}
@@ -76,22 +76,22 @@ void ofApp::draw() {
 	ofSetColor(cyanPrint);
 	for(int i = 0; i < currentLabels.size(); i++) {
 		int j = currentLabels[i];
-		ofLine(j, 0, j, 4);
+		ofDrawLine(j, 0, j, 4);
 	}
 	ofSetColor(magentaPrint);
 	for(int i = 0; i < previousLabels.size(); i++) {
 		int j = previousLabels[i];
-		ofLine(j, 4, j, 8);
+		ofDrawLine(j, 4, j, 8);
 	}
 	ofSetColor(yellowPrint);
 	for(int i = 0; i < newLabels.size(); i++) {
 		int j = newLabels[i];
-		ofLine(j, 8, j, 12);
+		ofDrawLine(j, 8, j, 12);
 	}
 	ofSetColor(ofColor::white);
 	for(int i = 0; i < deadLabels.size(); i++) {
 		int j = deadLabels[i];
-		ofLine(j, 12, j, 16);
+		ofDrawLine(j, 12, j, 16);
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ The rest of ofxCv is mostly helper functions (for example, `threshold()`) and wr
 `toCv()` is used to convert openFrameworks data to OpenCv data. For example:
 
 	ofImage img;
-	img.loadImage("image.png");
+	img.load("image.png");
 	Mat imgMat = toCv(img);
 
 This creates a wrapper for `img` called `imgMat`. To create a deep copy, use `clone()`:


### PR DESCRIPTION
Previous passes must have missed these.