### PR TITLE
Fixed calibration save, and two matrix issues within the multiple undistort variants.

### DIFF
--- a/libs/ofxCv/include/ofxCv/Calibration.h
+++ b/libs/ofxCv/include/ofxCv/Calibration.h
@@ -73,7 +73,7 @@ namespace ofxCv {
         void setDistortionCoefficients(float k1, float k2, float p1, float p2, float k3=0, float k4=0, float k5=0, float k6=0);
         
 		void undistort(Mat img, int interpolationMode = INTER_NEAREST);
-		void undistort(Mat src, Mat dst, int interpolationMode = INTER_NEAREST);
+		void undistort(Mat src, Mat &dst, int interpolationMode = INTER_NEAREST);
 		
 		ofVec2f undistort(ofVec2f& src) const;
 		void undistort(vector<ofVec2f>& src, vector<ofVec2f>& dst) const;

--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -324,7 +324,7 @@ namespace ofxCv {
 		const vector<unsigned int>& track(const vector<cv::Rect>& objects) {
 			const vector<unsigned int>& labels = Tracker<cv::Rect>::track(objects);
 			// add new objects, update old objects
-			for(int i = 0; i < labels.size(); i++) {
+			for(unsigned int i = 0; i < labels.size(); i++) {
 				unsigned int label = labels[i];
 				const cv::Rect& cur = getCurrent(label);
 				if(smoothed.count(label) > 0) {


### PR DESCRIPTION
Fixed a few things related to issues [175](https://github.com/kylemcdonald/ofxCv/issues/175) and [176](https://github.com/kylemcdonald/ofxCv/issues/176).

1. Changed the calibration save method to correctly export the vector of vector of points (otherwise it crashes when we try to reload it).
2. Changed the undistort functions to correctly handle the output parameter (by passing it by reference instead of by value, for edge case where it's currently empty) and using the undistorted camera matrix as newMatrix when undistorting points.