### PR TITLE
fixes some include issues

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -29,7 +29,9 @@ common:
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be
 	# specified here separated by spaces or one per line using +=
-	# ADDON_INCLUDES =
+	ADDON_INCLUDES = libs/ofxCv/include
+	ADDON_INCLUDES += libs/CLD/include/CLD
+	ADDON_INCLUDES += src
 	
 	# any special flag that should be passed to the compiler when using this
 	# addon

--- a/libs/ofxCv/include/ofxCv/Calibration.h
+++ b/libs/ofxCv/include/ofxCv/Calibration.h
@@ -52,8 +52,8 @@ namespace ofxCv {
 	public:
 		Calibration();
 		
-		void save(string filename, bool absolute = false) const;
-		void load(string filename, bool absolute = false);
+		void save(std::string filename, bool absolute = false) const;
+		void load(std::string filename, bool absolute = false);
 		void reset();
 
 		void setPatternType(CalibrationPattern patternType);
@@ -65,8 +65,8 @@ namespace ofxCv {
 		bool add(cv::Mat img);
 		bool clean(float minReprojectionError = 2.f);
 		bool calibrate();
-		bool calibrateFromDirectory(string directory);
-		bool findBoard(cv::Mat img, vector<cv::Point2f> &pointBuf, bool refine = true);
+		bool calibrateFromDirectory(std::string directory);
+		bool findBoard(cv::Mat img, std::vector<cv::Point2f> &pointBuf, bool refine = true);
 		void setIntrinsics(Intrinsics& distortedIntrinsics);
         void setDistortionCoefficients(float k1, float k2, float p1, float p2, float k3=0, float k4=0, float k5=0, float k6=0);
         
@@ -74,7 +74,7 @@ namespace ofxCv {
 		void undistort(cv::Mat src, cv::Mat dst, int interpolationMode = cv::INTER_NEAREST);
 		
 		ofVec2f undistort(ofVec2f& src) const;
-		void undistort(vector<ofVec2f>& src, vector<ofVec2f>& dst) const;
+		void undistort(std::vector<ofVec2f>& src, std::vector<ofVec2f>& dst) const;
 		
 		bool getTransformation(Calibration& dst, cv::Mat& rotation, cv::Mat& translation);
 		
@@ -91,7 +91,7 @@ namespace ofxCv {
 		int size() const;
 		cv::Size getPatternSize() const;
 		float getSquareSize() const;
-		static vector<cv::Point3f> createObjectPoints(cv::Size patternSize, float squareSize, CalibrationPattern patternType);
+		static std::vector<cv::Point3f> createObjectPoints(cv::Size patternSize, float squareSize, CalibrationPattern patternType);
 		
 		void customDraw();
 		void draw(int i) const;
@@ -99,7 +99,7 @@ namespace ofxCv {
 		void draw3d(int i) const;
 		
 		bool isReady();
-		vector<vector<cv::Point2f> > imagePoints;
+		std::vector<std::vector<cv::Point2f> > imagePoints;
 		
 	protected:
 		CalibrationPattern patternType;
@@ -109,11 +109,11 @@ namespace ofxCv {
 		
 		cv::Mat distCoeffs;
 		
-		vector<cv::Mat> boardRotations, boardTranslations;
-		vector<vector<cv::Point3f> > objectPoints;
+		std::vector<cv::Mat> boardRotations, boardTranslations;
+		std::vector<std::vector<cv::Point3f> > objectPoints;
 		
 		float reprojectionError;
-		vector<float> perViewErrors;
+		std::vector<float> perViewErrors;
 		
 		bool fillFrame;
 		cv::Mat undistortBuffer;

--- a/libs/ofxCv/include/ofxCv/Calibration.h
+++ b/libs/ofxCv/include/ofxCv/Calibration.h
@@ -22,30 +22,27 @@
 #include "ofxCv.h"
 
 namespace ofxCv {
-
-	using namespace cv;
-	
 	class Intrinsics {
 	public:
         void setup(float focalLengthMm, cv::Size imageSizePx, cv::Size2f sensorSizeMm, cv::Point2d principalPointPct = cv::Point2d(.5,.5));
-		void setup(Mat cameraMatrix, cv::Size imageSizePx, cv::Size2f sensorSizeMm = cv::Size2f(0, 0));
+		void setup(cv::Mat cameraMatrix, cv::Size imageSizePx, cv::Size2f sensorSizeMm = cv::Size2f(0, 0));
 		void setImageSize(cv::Size imgSize);
-		Mat getCameraMatrix() const;
+		cv::Mat getCameraMatrix() const;
 		cv::Size getImageSize() const;
 		cv::Size2f getSensorSize() const;
 		cv::Point2d getFov() const;
 		double getFocalLength() const;
 		double getAspectRatio() const;
-		Point2d getPrincipalPoint() const;
+		cv::Point2d getPrincipalPoint() const;
 		void loadProjectionMatrix(float nearDist = 10., float farDist = 10000., cv::Point2d viewportOffset = cv::Point2d(0, 0)) const;
 	protected:
         void updateValues();
-		Mat cameraMatrix;
+		cv::Mat cameraMatrix;
         cv::Size imageSize;
         cv::Size2f sensorSize;
 		cv::Point2d fov;
 		double focalLength, aspectRatio;
-		Point2d principalPoint;
+		cv::Point2d principalPoint;
 	};
 	
 	enum CalibrationPattern {CHESSBOARD, CIRCLES_GRID, ASYMMETRIC_CIRCLES_GRID};
@@ -64,28 +61,28 @@ namespace ofxCv {
 		/// set this to the pixel size of your smallest square. default is 11
 		void setSubpixelSize(int subpixelSize);
 
-		bool add(Mat img);
+		bool add(cv::Mat img);
 		bool clean(float minReprojectionError = 2.f);
 		bool calibrate();
 		bool calibrateFromDirectory(string directory);
-		bool findBoard(Mat img, vector<Point2f> &pointBuf, bool refine = true);
+		bool findBoard(cv::Mat img, vector<cv::Point2f> &pointBuf, bool refine = true);
 		void setIntrinsics(Intrinsics& distortedIntrinsics);
         void setDistortionCoefficients(float k1, float k2, float p1, float p2, float k3=0, float k4=0, float k5=0, float k6=0);
         
-		void undistort(Mat img, int interpolationMode = INTER_NEAREST);
-		void undistort(Mat src, Mat dst, int interpolationMode = INTER_NEAREST);
+		void undistort(cv::Mat img, int interpolationMode = cv::INTER_NEAREST);
+		void undistort(cv::Mat src, cv::Mat dst, int interpolationMode = cv::INTER_NEAREST);
 		
 		ofVec2f undistort(ofVec2f& src) const;
 		void undistort(vector<ofVec2f>& src, vector<ofVec2f>& dst) const;
 		
-		bool getTransformation(Calibration& dst, Mat& rotation, Mat& translation);
+		bool getTransformation(Calibration& dst, cv::Mat& rotation, cv::Mat& translation);
 		
 		float getReprojectionError() const;
 		float getReprojectionError(int i) const;
 		
 		const Intrinsics& getDistortedIntrinsics() const;
 		const Intrinsics& getUndistortedIntrinsics() const;
-		Mat getDistCoeffs() const;
+		cv::Mat getDistCoeffs() const;
 		
 		// if you want a wider fov, say setFillFrame(false) before load() or calibrate()
 		void setFillFrame(bool fillFrame);
@@ -93,7 +90,7 @@ namespace ofxCv {
 		int size() const;
 		cv::Size getPatternSize() const;
 		float getSquareSize() const;
-		static vector<Point3f> createObjectPoints(cv::Size patternSize, float squareSize, CalibrationPattern patternType);
+		static vector<cv::Point3f> createObjectPoints(cv::Size patternSize, float squareSize, CalibrationPattern patternType);
 		
 		void customDraw();
 		void draw(int i) const;
@@ -101,25 +98,25 @@ namespace ofxCv {
 		void draw3d(int i) const;
 		
 		bool isReady();
-		vector<vector<Point2f> > imagePoints;
+		vector<vector<cv::Point2f> > imagePoints;
 		
 	protected:
 		CalibrationPattern patternType;
 		cv::Size patternSize, addedImageSize, subpixelSize;
 		float squareSize;
-		Mat grayMat;
+		cv::Mat grayMat;
 		
-		Mat distCoeffs;
+		cv::Mat distCoeffs;
 		
-		vector<Mat> boardRotations, boardTranslations;
-		vector<vector<Point3f> > objectPoints;
+		vector<cv::Mat> boardRotations, boardTranslations;
+		vector<vector<cv::Point3f> > objectPoints;
 		
 		float reprojectionError;
 		vector<float> perViewErrors;
 		
 		bool fillFrame;
-		Mat undistortBuffer;
-		Mat undistortMapX, undistortMapY;
+		cv::Mat undistortBuffer;
+		cv::Mat undistortMapX, undistortMapY;
 		
 		void updateObjectPoints();
 		void updateReprojectionError();

--- a/libs/ofxCv/include/ofxCv/Calibration.h
+++ b/libs/ofxCv/include/ofxCv/Calibration.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "ofxCv.h"
+#include "ofNode.h"
 
 namespace ofxCv {
 	class Intrinsics {

--- a/libs/ofxCv/include/ofxCv/ContourFinder.h
+++ b/libs/ofxCv/include/ofxCv/ContourFinder.h
@@ -44,12 +44,12 @@ namespace ofxCv {
 			findContours(toCv(img));
 		}
 		void findContours(cv::Mat img);
-		const vector<vector<cv::Point> >& getContours() const;
-		const vector<ofPolyline>& getPolylines() const;
-		const vector<cv::Rect>& getBoundingRects() const;
+		const std::vector<std::vector<cv::Point> >& getContours() const;
+		const std::vector<ofPolyline>& getPolylines() const;
+		const std::vector<cv::Rect>& getBoundingRects() const;
 		
 		unsigned int size() const;
-		vector<cv::Point>& getContour(unsigned int i);
+		std::vector<cv::Point>& getContour(unsigned int i);
 		ofPolyline& getPolyline(unsigned int i);
 		
 		cv::Rect getBoundingRect(unsigned int i) const;
@@ -59,12 +59,12 @@ namespace ofxCv {
 		cv::Vec2f getBalance(unsigned int i) const; // difference between centroid and center
 		double getContourArea(unsigned int i) const;
 		double getArcLength(unsigned int i) const;
-		vector<cv::Point> getConvexHull(unsigned int i) const;
-		vector<cv::Vec4i> getConvexityDefects(unsigned int i) const;
+		std::vector<cv::Point> getConvexHull(unsigned int i) const;
+		std::vector<cv::Vec4i> getConvexityDefects(unsigned int i) const;
 		cv::RotatedRect getMinAreaRect(unsigned int i) const;
 		cv::Point2f getMinEnclosingCircle(unsigned int i, float& radius) const;
 		cv::RotatedRect getFitEllipse(unsigned int i) const;
-		vector<cv::Point> getFitQuad(unsigned int i) const;
+		std::vector<cv::Point> getFitQuad(unsigned int i) const;
 		cv::Vec2f getVelocity(unsigned int i) const;
 		
 		RectTracker& getTracker();
@@ -103,11 +103,11 @@ namespace ofxCv {
 		float minArea, maxArea;
 		bool minAreaNorm, maxAreaNorm;
 		
-		vector<vector<cv::Point> > contours;
-		vector<ofPolyline> polylines;
+		std::vector<std::vector<cv::Point> > contours;
+		std::vector<ofPolyline> polylines;
 		
 		RectTracker tracker;
-		vector<cv::Rect> boundingRects;
+		std::vector<cv::Rect> boundingRects;
 
 		int contourFindingMode;
 		bool sortBySize;

--- a/libs/ofxCv/include/ofxCv/Distance.h
+++ b/libs/ofxCv/include/ofxCv/Distance.h
@@ -5,12 +5,10 @@
 #include <cstdlib>
 
 namespace ofxCv {
-
-	using namespace std;
 	
 	// edit distance is the number of transformations required to turn one string into another
-	int editDistance(const string& a, const string& b);
+	int editDistance(const std::string& a, const std::string& b);
 	
 	// cross correlation using edit distance gives the most representative string from a set
-	const string& mostRepresentative(const vector<string>& strs);
+	const std::string& mostRepresentative(const std::vector<std::string>& strs);
 }

--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -73,22 +73,22 @@ namespace ofxCv {
 		void setPyramidLevels(int levels);
 		
 		//returns tracking features for this image
-		vector<ofPoint> getFeatures();
-		vector<ofPoint> getCurrent();
-		vector<ofVec2f> getMotion();
+		std::vector<ofPoint> getFeatures();
+		std::vector<ofPoint> getCurrent();
+		std::vector<ofVec2f> getMotion();
 		
 		// recalculates features to track
 		void resetFeaturesToTrack();
-		void setFeaturesToTrack(const vector<ofVec2f> & features);
-		void setFeaturesToTrack(const vector<cv::Point2f> & features);
+		void setFeaturesToTrack(const std::vector<ofVec2f> & features);
+		void setFeaturesToTrack(const std::vector<cv::Point2f> & features);
         void resetFlow();
 	protected:
 		
 		void drawFlow(ofRectangle r);
 		void calcFlow(cv::Mat prev, cv::Mat next);
-		void calcFeaturesToTrack(vector<cv::Point2f> & features, cv::Mat next);
+		void calcFeaturesToTrack(std::vector<cv::Point2f> & features, cv::Mat next);
 		
-		vector<cv::Point2f> prevPts, nextPts;
+		std::vector<cv::Point2f> prevPts, nextPts;
 		
 		//LK feature finding parameters
 		int windowSize;
@@ -105,10 +105,10 @@ namespace ofxCv {
 		bool calcFeaturesNextFrame;
 		
 		//pyramid + err/status data
-		vector<cv::Mat> pyramid;
-		vector<cv::Mat> prevPyramid;
-		vector<uchar> status;
-		vector<float> err;
+		std::vector<cv::Mat> pyramid;
+		std::vector<cv::Mat> prevPyramid;
+		std::vector<uchar> status;
+		std::vector<float> err;
 	};
 	
 	class FlowFarneback : public Flow {

--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -4,8 +4,6 @@
 
 namespace ofxCv {
 	
-	using namespace cv;
-	
 	class Flow {
 	public:
         // should constructor be protected?
@@ -21,7 +19,7 @@ namespace ofxCv {
 		void calcOpticalFlow(T& lastImage, T& currentImage) {
             calcOpticalFlow(toCv(lastImage), toCv(currentImage));
         }
-		void calcOpticalFlow(Mat lastImage, Mat currentImage);
+		void calcOpticalFlow(cv::Mat lastImage, cv::Mat currentImage);
 		
 		//call with subsequent images to do running optical flow. 
 		//the Flow class internally stores the last image for convenience
@@ -29,7 +27,7 @@ namespace ofxCv {
 		void calcOpticalFlow(T& currentImage) {
             calcOpticalFlow(toCv(currentImage));
         }
-		void calcOpticalFlow(Mat nextImage);
+		void calcOpticalFlow(cv::Mat nextImage);
 		
 		void draw();
 		void draw(float x, float y);
@@ -41,13 +39,13 @@ namespace ofxCv {
         virtual void resetFlow();
         
     private:
-		Mat last, curr;
+		cv::Mat last, curr;
         
     protected:
 		bool hasFlow;
 		
 		//specific flow implementation
-		virtual void calcFlow(Mat prev, Mat next) = 0;
+		virtual void calcFlow(cv::Mat prev, cv::Mat next) = 0;
 		//specific drawing implementation
 		virtual void drawFlow(ofRectangle r) = 0;
 	};
@@ -87,8 +85,8 @@ namespace ofxCv {
 	protected:
 		
 		void drawFlow(ofRectangle r);
-		void calcFlow(Mat prev, Mat next);
-		void calcFeaturesToTrack(vector<cv::Point2f> & features, Mat next);
+		void calcFlow(cv::Mat prev, cv::Mat next);
+		void calcFeaturesToTrack(vector<cv::Point2f> & features, cv::Mat next);
 		
 		vector<cv::Point2f> prevPts, nextPts;
 		
@@ -130,7 +128,7 @@ namespace ofxCv {
 		void setPolySigma(float polySigma);
 		void setUseGaussian(bool gaussian);
 		
-        Mat& getFlow();
+		cv::Mat& getFlow();
 		ofVec2f getTotalFlow();
 		ofVec2f getAverageFlow();		
 		ofVec2f getFlowOffset(int x, int y);
@@ -145,7 +143,7 @@ namespace ofxCv {
 		cv::Mat flow;
 
 		void drawFlow(ofRectangle rect);
-		void calcFlow(Mat prev, Mat next);
+		void calcFlow(cv::Mat prev, cv::Mat next);
 		
 		float pyramidScale;
 		int numLevels;

--- a/libs/ofxCv/include/ofxCv/Helpers.h
+++ b/libs/ofxCv/include/ofxCv/Helpers.h
@@ -10,17 +10,15 @@
 
 namespace ofxCv {
 	
-	using namespace cv;
-	
-	ofMatrix4x4 makeMatrix(Mat rotation, Mat translation);
+	ofMatrix4x4 makeMatrix(cv::Mat rotation, cv::Mat translation);
 	void applyMatrix(const ofMatrix4x4& matrix);
 	
-	void drawMat(Mat& mat, float x, float y);
-	void drawMat(Mat& mat, float x, float y, float width, float height);
+	void drawMat(cv::Mat& mat, float x, float y);
+	void drawMat(cv::Mat& mat, float x, float y, float width, float height);
 	
 	template <class T>
 	ofVec2f findMaxLocation(T& img) {
-		Mat mat = toCv(img);
+		cv::Mat mat = toCv(img);
 		double minVal, maxVal;
 		cv::Point minLoc, maxLoc;
 		minMaxLoc(mat, &minVal, &maxVal, &minLoc, &maxLoc);
@@ -28,9 +26,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat meanCols(T& img) {
-		Mat mat = toCv(img);
-		Mat colMat(mat.cols, 1, mat.type());
+	cv::Mat meanCols(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat colMat(mat.cols, 1, mat.type());
 		for(int i = 0; i < mat.cols; i++) {
 			colMat.row(i) = mean(mat.col(i));
 		}	
@@ -38,9 +36,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat meanRows(T& img) {
-		Mat mat = toCv(img);
-		Mat rowMat(mat.rows, 1, mat.type());
+	cv::Mat meanRows(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat rowMat(mat.rows, 1, mat.type());
 		for(int i = 0; i < mat.rows; i++) {
 			rowMat.row(i) = mean(mat.row(i));
 		}
@@ -48,9 +46,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat sumCols(T& img) {
-		Mat mat = toCv(img);
-		Mat colMat(mat.cols, 1, CV_32FC1);
+	cv::Mat sumCols(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat colMat(mat.cols, 1, CV_32FC1);
 		for(int i = 0; i < mat.cols; i++) {
 			colMat.row(i) = sum(mat.col(i));
 		}	
@@ -58,9 +56,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat sumRows(T& img) {
-		Mat mat = toCv(img);
-		Mat rowMat(mat.rows, 1, CV_32FC1);
+	cv::Mat sumRows(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat rowMat(mat.rows, 1, CV_32FC1);
 		for(int i = 0; i < mat.rows; i++) {
 			rowMat.row(i) = sum(mat.row(i));
 		}
@@ -68,9 +66,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat minCols(T& img) {
-		Mat mat = toCv(img);
-		Mat colMat(mat.cols, 1, CV_32FC1);
+	cv::Mat minCols(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat colMat(mat.cols, 1, CV_32FC1);
 		double minVal, maxVal;
 		for(int i = 0; i < mat.cols; i++) {
 			minMaxLoc(mat.col(i), &minVal, &maxVal); 
@@ -80,9 +78,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat minRows(T& img) {
-		Mat mat = toCv(img);
-		Mat rowMat(mat.rows, 1, CV_32FC1);
+	cv::Mat minRows(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat rowMat(mat.rows, 1, CV_32FC1);
 		double minVal, maxVal;
 		for(int i = 0; i < mat.rows; i++) {
 			minMaxLoc(mat.row(i), &minVal, &maxVal); 
@@ -92,9 +90,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat maxCols(T& img) {
-		Mat mat = toCv(img);
-		Mat colMat(mat.cols, 1, CV_32FC1);
+	cv::Mat maxCols(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat colMat(mat.cols, 1, CV_32FC1);
 		double minVal, maxVal;
 		for(int i = 0; i < mat.cols; i++) {
 			minMaxLoc(mat.col(i), &minVal, &maxVal); 
@@ -104,9 +102,9 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	Mat maxRows(T& img) {
-		Mat mat = toCv(img);
-		Mat rowMat(mat.rows, 1, CV_32FC1);
+	cv::Mat maxRows(T& img) {
+		cv::Mat mat = toCv(img);
+		cv::Mat rowMat(mat.rows, 1, CV_32FC1);
 		double minVal, maxVal;
 		for(int i = 0; i < mat.rows; i++) {
 			minMaxLoc(mat.row(i), &minVal, &maxVal); 
@@ -115,51 +113,51 @@ namespace ofxCv {
 		return rowMat;
 	}
 	
-	int findFirst(const Mat& arr, unsigned char target);
-	int findLast(const Mat& arr, unsigned char target);
+	int findFirst(const cv::Mat& arr, unsigned char target);
+	int findLast(const cv::Mat& arr, unsigned char target);
 	
 	template <class T>
 	void getBoundingBox(T& img, ofRectangle& box, int thresh, bool invert) {
-		Mat mat = toCv(img);
-		int flags = (invert ? THRESH_BINARY_INV : THRESH_BINARY);
+		cv::Mat mat = toCv(img);
+		int flags = (invert ? cv::THRESH_BINARY_INV : cv::THRESH_BINARY);
 		
-		Mat rowMat = meanRows(mat);
+		cv::Mat rowMat = meanRows(mat);
 		threshold(rowMat, rowMat, thresh, 255, flags);
 		box.y = findFirst(rowMat, 255);
 		box.height = findLast(rowMat, 255);
 		box.height -= box.y;
 		
-		Mat colMat = meanCols(mat);
+		cv::Mat colMat = meanCols(mat);
 		threshold(colMat, colMat, thresh, 255, flags);
 		box.x = findFirst(colMat, 255);
 		box.width = findLast(colMat, 255);
 		box.width -= box.x;
 	}
 	
-	float weightedAverageAngle(const vector<Vec4i>& lines);
+	float weightedAverageAngle(const vector<cv::Vec4i>& lines);
 	
 	// (nearest point) to the two given lines
 	template <class T>
-	Point3_<T> intersectLineLine(Point3_<T> lineStart1, Point3_<T> lineEnd1, Point3_<T> lineStart2, Point3_<T> lineEnd2) {
-		Point3_<T> v1(lineEnd1 - lineStart1), v2(lineEnd2 - lineStart2);
+	cv::Point3_<T> intersectLineLine(cv::Point3_<T> lineStart1, cv::Point3_<T> lineEnd1, cv::Point3_<T> lineStart2, cv::Point3_<T> lineEnd2) {
+		cv::Point3_<T> v1(lineEnd1 - lineStart1), v2(lineEnd2 - lineStart2);
 		T v1v1 = v1.dot(v1), v2v2 = v2.dot(v2), v1v2 = v1.dot(v2), v2v1 = v2.dot(v1);
-		Mat_<T> lambda = (1. / (v1v1 * v2v2 - v1v2 * v1v2))
-		* ((Mat_<T>(2, 2) << v2v2, v1v2, v2v1, v1v1)
-			 * (Mat_<T>(2, 1) << v1.dot(lineStart2 - lineStart1), v2.dot(lineStart1 - lineStart2)));
+		cv::Mat_<T> lambda = (1. / (v1v1 * v2v2 - v1v2 * v1v2))
+		* ((cv::Mat_<T>(2, 2) << v2v2, v1v2, v2v1, v1v1)
+			 * (cv::Mat_<T>(2, 1) << v1.dot(lineStart2 - lineStart1), v2.dot(lineStart1 - lineStart2)));
 		return (1./2) * ((lineStart1 + v1 * lambda(0)) + (lineStart2 + v2 * lambda(1)));
 	}
 	
 	// (nearest point on a line) to the given point
 	template <class T>
-	Point3_<T> intersectPointLine(Point3_<T> point, Point3_<T> lineStart, Point3_<T> lineEnd) {
-		Point3_<T> ray = lineEnd - lineStart;
+	cv::Point3_<T> intersectPointLine(cv::Point3_<T> point, cv::Point3_<T> lineStart, cv::Point3_<T> lineEnd) {
+		cv::Point3_<T> ray = lineEnd - lineStart;
 		T u = (point - lineStart).dot(ray) / ray.dot(ray);
 		return lineStart + u * ray;
 	}
 	
 	// (nearest point on a ray) to the given point
 	template <class T>
-	Point3_<T> intersectPointRay(Point3_<T> point, Point3_<T> ray) {
+	cv::Point3_<T> intersectPointRay(cv::Point3_<T> point, cv::Point3_<T> ray) {
 		return ray * (point.dot(ray) / ray.dot(ray));
 	}
 	
@@ -167,7 +165,7 @@ namespace ofxCv {
 	// here is a description of the algorithm http://homepages.inf.ed.ac.uk/rbf/HIPR2/thin.htm
 	template <class T>
 	void thin(T& img) {
-		Mat mat = toCv(img);
+		cv::Mat mat = toCv(img);
 		int w = mat.cols, h = mat.rows;
 		int ia1=-w-1,ia2=-w-0,ia3=-w+1,ib1=-0-1,ib3=-0+1,ic1=+w-1,ic2=+w-0,ic3=+w+1;
 		unsigned char* p = mat.ptr<unsigned char>();
@@ -192,23 +190,23 @@ namespace ofxCv {
 	}
 	
 	// given a vector of lines, this function will find the average angle
-	float weightedAverageAngle(const vector<Vec4i>& lines);
+	float weightedAverageAngle(const vector<cv::Vec4i>& lines);
 	
 	// finds the average angle of hough lines, unrotates by that amount and
 	// returns the average rotation. you can supply your own thresholded image
 	// for hough lines, or let it run canny detection for you.
 	template <class S, class T, class D>
 	float autorotate(S& src, D& dst, float threshold1 = 50, float threshold2 = 200) {
-		Mat thresh;
-		ofxCv::Canny(src, thresh, threshold1, threshold2);
+		cv::Mat thresh;
+		cv::Canny(src, thresh, threshold1, threshold2);
 		return autorotate(src, thresh, dst);
 	}
 	
 	template <class S, class T, class D>
 	float autorotate(S& src, T& thresh, D& dst) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), threshMat = toCv(thresh);
-		vector<Vec4i> lines;
+		cv::Mat srcMat = toCv(src), threshMat = toCv(thresh);
+		vector<cv::Vec4i> lines;
 		double distanceResolution = 1;
 		double angleResolution = CV_PI / 180;
 		// these three values are just heuristics that have worked for me

--- a/libs/ofxCv/include/ofxCv/Helpers.h
+++ b/libs/ofxCv/include/ofxCv/Helpers.h
@@ -6,7 +6,9 @@
 #pragma once
 
 #include "opencv2/opencv.hpp"
-#include "ofMain.h"
+#include "ofVectorMath.h"
+#include "ofRectangle.h"
+#include "ofColor.h"
 
 namespace ofxCv {
 	

--- a/libs/ofxCv/include/ofxCv/Helpers.h
+++ b/libs/ofxCv/include/ofxCv/Helpers.h
@@ -208,7 +208,7 @@ namespace ofxCv {
 	float autorotate(S& src, T& thresh, D& dst) {
 		imitate(dst, src);
 		cv::Mat srcMat = toCv(src), threshMat = toCv(thresh);
-		vector<cv::Vec4i> lines;
+		std::vector<cv::Vec4i> lines;
 		double distanceResolution = 1;
 		double angleResolution = CV_PI / 180;
 		// these three values are just heuristics that have worked for me
@@ -221,7 +221,7 @@ namespace ofxCv {
 		return rotationAmount;
 	}
 	
-	vector<cv::Point2f> getConvexPolygon(const vector<cv::Point2f>& convexHull, int targetPoints);
+	std::vector<cv::Point2f> getConvexPolygon(const std::vector<cv::Point2f>& convexHull, int targetPoints);
 	
 	static const ofColor cyanPrint = ofColor::fromHex(0x00abec);
 	static const ofColor magentaPrint = ofColor::fromHex(0xec008c);

--- a/libs/ofxCv/include/ofxCv/Kalman.h
+++ b/libs/ofxCv/include/ofxCv/Kalman.h
@@ -4,13 +4,11 @@
 
 namespace ofxCv {
 	
-	using namespace cv;
-	
 	// Kalman filter for positioning
 	template <class T>
 	class KalmanPosition_ {
-		KalmanFilter KF;
-		Mat_<T> measurement, prediction, estimated;
+		cv::KalmanFilter KF;
+		cv::Mat_<T> measurement, prediction, estimated;
 	public:
 		// smoothness, rapidness: smaller is more smooth/rapid
 		// bUseAccel: set true to smooth out velocity

--- a/libs/ofxCv/include/ofxCv/Kalman.h
+++ b/libs/ofxCv/include/ofxCv/Kalman.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ofxCv.h"
+#include "ofVectorMath.h"
 
 namespace ofxCv {
 	

--- a/libs/ofxCv/include/ofxCv/ObjectFinder.h
+++ b/libs/ofxCv/include/ofxCv/ObjectFinder.h
@@ -21,6 +21,7 @@
 
 #include "ofxCv/Utilities.h"
 #include "ofxCv/Tracker.h"
+#include "ofRectangle.h"
 
 #include "ofxCv.h"
 namespace ofxCv {

--- a/libs/ofxCv/include/ofxCv/ObjectFinder.h
+++ b/libs/ofxCv/include/ofxCv/ObjectFinder.h
@@ -71,7 +71,7 @@ namespace ofxCv {
 		float minSizeScale, maxSizeScale;
 		cv::Mat gray, graySmall;
 		cv::CascadeClassifier classifier;
-		vector<cv::Rect> objects;
+		std::vector<cv::Rect> objects;
 		RectTracker tracker;
 	};
 }

--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -131,13 +131,13 @@ namespace ofxCv {
 		virtual ~Tracker(){};
 		void setPersistence(unsigned int persistence);
 		void setMaximumDistance(float maximumDistance);
-		virtual const vector<unsigned int>& track(const vector<T>& objects);
+		virtual const std::vector<unsigned int>& track(const std::vector<T>& objects);
 		
 		// organized in the order received by track()
-		const vector<unsigned int>& getCurrentLabels() const;
-		const vector<unsigned int>& getPreviousLabels() const;
-		const vector<unsigned int>& getNewLabels() const;
-		const vector<unsigned int>& getDeadLabels() const;
+		const std::vector<unsigned int>& getCurrentLabels() const;
+		const std::vector<unsigned int>& getPreviousLabels() const;
+		const std::vector<unsigned int>& getNewLabels() const;
+		const std::vector<unsigned int>& getDeadLabels() const;
 		unsigned int getLabelFromIndex(unsigned int i) const;
 		
 		// organized by label
@@ -161,7 +161,7 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	const vector<unsigned int>& Tracker<T>::track(const vector<T>& objects) {
+	const std::vector<unsigned int>& Tracker<T>::track(const std::vector<T>& objects) {
 		previous = current;
 		int n = objects.size();
 		int m = previous.size();
@@ -169,7 +169,7 @@ namespace ofxCv {
 		// build NxM distance matrix
 		typedef std::pair<int, int> MatchPair;
 		typedef std::pair<MatchPair, float> MatchDistancePair;
-		vector<MatchDistancePair> all;
+		std::vector<MatchDistancePair> all;
 		for(int i = 0; i < n; i++) {
 			for(int j = 0; j < m; j++) {
 				float curDistance = trackingDistance(objects[i], previous[j].object);
@@ -186,8 +186,8 @@ namespace ofxCv {
 		currentLabels.clear();
 		currentLabels.resize(n);
 		current.clear();
-		vector<bool> matchedObjects(n, false);
-		vector<bool> matchedPrevious(m, false);
+		std::vector<bool> matchedObjects(n, false);
+		std::vector<bool> matchedPrevious(m, false);
 		// walk through matches in order
 		for(int k = 0; k < (int)all.size(); k++) {
 			MatchPair& match = all[k].first;
@@ -245,17 +245,17 @@ namespace ofxCv {
 	}
 	
 	template <class T>
-	const vector<unsigned int>& Tracker<T>::getCurrentLabels() const {
+	const std::vector<unsigned int>& Tracker<T>::getCurrentLabels() const {
 		return currentLabels;
 	}
 	
 	template <class T>
-	const vector<unsigned int>& Tracker<T>::getPreviousLabels() const {
+	const std::vector<unsigned int>& Tracker<T>::getPreviousLabels() const {
 		return previousLabels;
 	}
 	
 	template <class T>
-	const vector<unsigned int>& Tracker<T>::getNewLabels() const {
+	const std::vector<unsigned int>& Tracker<T>::getNewLabels() const {
 		return newLabels;
 	}
 	
@@ -318,8 +318,8 @@ namespace ofxCv {
 		float getSmoothingRate() const {
 			return smoothingRate;
 		}
-		const vector<unsigned int>& track(const vector<cv::Rect>& objects) {
-			const vector<unsigned int>& labels = Tracker<cv::Rect>::track(objects);
+		const std::vector<unsigned int>& track(const std::vector<cv::Rect>& objects) {
+			const std::vector<unsigned int>& labels = Tracker<cv::Rect>::track(objects);
 			// add new objects, update old objects
 			for(int i = 0; i < labels.size(); i++) {
 				unsigned int label = labels[i];
@@ -398,10 +398,10 @@ namespace ofxCv {
 	template <class T, class F>
 	class TrackerFollower : public Tracker<T> {
 	protected:
-		vector<unsigned int> labels;
-		vector<F> followers;
+		std::vector<unsigned int> labels;
+		std::vector<F> followers;
 	public:
-		const vector<unsigned int>& track(const vector<T>& objects) {
+		const std::vector<unsigned int>& track(const std::vector<T>& objects) {
 			Tracker<T>::track(objects);
 			// kill missing, update old
 			for(int i = 0; i < labels.size(); i++) {
@@ -430,7 +430,7 @@ namespace ofxCv {
 			}
 			return labels;
 		}
-		vector<F>& getFollowers() {
+		std::vector<F>& getFollowers() {
 			return followers;
 		}
 	};

--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -50,9 +50,6 @@
 #include "ofMath.h"
 
 namespace ofxCv {
-	
-	using namespace cv;
-	
 	float trackingDistance(const cv::Rect& a, const cv::Rect& b);
 	float trackingDistance(const cv::Point2f& a, const cv::Point2f& b);
 	

--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -13,17 +13,14 @@
 #include "opencv2/opencv.hpp"
 
 namespace ofxCv {
-	
-	using namespace cv;
-	
 	// these functions are for accessing Mat, ofPixels and ofImage consistently.
 	// they're very important for imitate().
 	
 	// width, height
 	template <class T> inline int getWidth(T& src) {return src.getWidth();}
 	template <class T> inline int getHeight(T& src) {return src.getHeight();}
-	inline int getWidth(Mat& src) {return src.cols;}
-	inline int getHeight(Mat& src) {return src.rows;}
+	inline int getWidth(cv::Mat& src) {return src.cols;}
+	inline int getHeight(cv::Mat& src) {return src.rows;}
 	template <class T> inline bool getAllocated(T& src) {
 		return getWidth(src) > 0 && getHeight(src) > 0;
 	}
@@ -32,7 +29,7 @@ namespace ofxCv {
     inline int getDepth(int cvImageType) {
         return CV_MAT_DEPTH(cvImageType);
     }
-	inline int getDepth(Mat& mat) {
+	inline int getDepth(cv::Mat& mat) {
 		return mat.depth();
 	}
     inline int getDepth(ofTexture& tex) {
@@ -91,7 +88,7 @@ namespace ofxCv {
 			case OF_IMAGE_GRAYSCALE: default: return 1;
 		}
 	}
-	inline int getChannels(Mat& mat) {
+	inline int getChannels(cv::Mat& mat) {
 		return mat.channels();
 	}
     inline int getChannels(ofTexture& tex) {
@@ -185,7 +182,7 @@ namespace ofxCv {
             img.allocate(width, height, getGlImageType(cvType));
         }
     }
-	inline void allocate(Mat& img, int width, int height, int cvType) {
+	inline void allocate(cv::Mat& img, int width, int height, int cvType) {
         if (getWidth(img) != width ||
             getHeight(img) != height ||
             getCvImageType(img) != cvType) {
@@ -213,7 +210,7 @@ namespace ofxCv {
 	
 	// maximum possible values for that depth or matrix
 	float getMaxVal(int cvDepth);
-	float getMaxVal(const Mat& mat);
+	float getMaxVal(const cv::Mat& mat);
 	int getTargetChannelsFromCode(int conversionCode);
     
 	// toCv functions
@@ -226,27 +223,27 @@ namespace ofxCv {
 	// is used for small objects where the compiler can optimize the copying if
 	// necessary. the reference is avoided to make inline toCv/toOf use easier.
 	
-	Mat toCv(Mat& mat);
-	template <class T> inline Mat toCv(ofPixels_<T>& pix) {
-		return Mat(pix.getHeight(), pix.getWidth(), getCvImageType(pix), pix.getData(), 0);
+	cv::Mat toCv(cv::Mat& mat);
+	template <class T> inline cv::Mat toCv(ofPixels_<T>& pix) {
+		return cv::Mat(pix.getHeight(), pix.getWidth(), getCvImageType(pix), pix.getData(), 0);
 	}
-	template <class T> inline Mat toCv(ofBaseHasPixels_<T>& img) {
+	template <class T> inline cv::Mat toCv(ofBaseHasPixels_<T>& img) {
 		return toCv(img.getPixels());
 	}
-	Mat toCv(ofMesh& mesh);
-	Point2f toCv(ofVec2f vec);
-	Point3f toCv(ofVec3f vec);
+	cv::Mat toCv(ofMesh& mesh);
+	cv::Point2f toCv(ofVec2f vec);
+	cv::Point3f toCv(ofVec3f vec);
 	cv::Rect toCv(ofRectangle rect);
 	vector<cv::Point2f> toCv(const ofPolyline& polyline);
 	vector<cv::Point2f> toCv(const vector<ofVec2f>& points);
 	vector<cv::Point3f> toCv(const vector<ofVec3f>& points);
-	Scalar toCv(ofColor color);
+	cv::Scalar toCv(ofColor color);
 	
 	// cross-toolkit, cross-bitdepth copying
 	template <class S, class D>
 	void copy(S& src, D& dst, int dstDepth) {
 		imitate(dst, src, getCvImageType(getChannels(src), dstDepth));
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		if(srcMat.type() == dstMat.type()) {
 			srcMat.copyTo(dstMat);
 		} else {
@@ -270,8 +267,8 @@ namespace ofxCv {
 	}
 	
 	// toOf functions
-	ofVec2f toOf(Point2f point);
-	ofVec3f toOf(Point3f point);
+	ofVec2f toOf(cv::Point2f point);
+	ofVec3f toOf(cv::Point3f point);
 	ofRectangle toOf(cv::Rect rect);
 	ofPolyline toOf(cv::RotatedRect rect);
 	template <class T> inline ofPolyline toOf(const vector<cv::Point_<T> >& contour) {
@@ -285,11 +282,11 @@ namespace ofxCv {
 		return polyline;
 	}
 	template <class T>
-	void toOf(Mat mat, ofPixels_<T>& pixels) {
+	void toOf(cv::Mat mat, ofPixels_<T>& pixels) {
 		pixels.setFromExternalPixels(mat.ptr<T>(), mat.cols, mat.rows, mat.channels());
 	}
 	template <class T>
-	void toOf(Mat mat, ofImage_<T>& img) {
+	void toOf(cv::Mat mat, ofImage_<T>& img) {
 		imitate(img, mat);
 		toOf(mat, img.getPixels());
 	}

--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -9,8 +9,13 @@
 
 #pragma once
 
-#include "ofMain.h"
 #include "opencv2/opencv.hpp"
+#include "ofRectangle.h"
+#include "ofTexture.h"
+#include "ofPixels.h"
+#include "ofBaseTypes.h"
+#include "ofPolyline.h"
+#include "ofVectorMath.h"
 
 namespace ofxCv {
 	// these functions are for accessing Mat, ofPixels and ofImage consistently.
@@ -190,8 +195,7 @@ namespace ofxCv {
 		}
 	}
 	// ofVideoPlayer/Grabber can't be allocated, so we assume we don't need to do anything
-	inline void allocate(ofVideoPlayer& img, int width, int height, int cvType) {}
-	inline void allocate(ofVideoGrabber& img, int width, int height, int cvType) {}
+	inline void allocate(ofBaseVideoDraws & img, int width, int height, int cvType) {}
 	
 	// imitate() is good for preparing buffers
 	// it's like allocate(), but uses the size and type of the original as a reference

--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -238,9 +238,9 @@ namespace ofxCv {
 	cv::Point2f toCv(ofVec2f vec);
 	cv::Point3f toCv(ofVec3f vec);
 	cv::Rect toCv(ofRectangle rect);
-	vector<cv::Point2f> toCv(const ofPolyline& polyline);
-	vector<cv::Point2f> toCv(const vector<ofVec2f>& points);
-	vector<cv::Point3f> toCv(const vector<ofVec3f>& points);
+	std::vector<cv::Point2f> toCv(const ofPolyline& polyline);
+	std::vector<cv::Point2f> toCv(const std::vector<ofVec2f>& points);
+	std::vector<cv::Point3f> toCv(const std::vector<ofVec3f>& points);
 	cv::Scalar toCv(ofColor color);
 	
 	// cross-toolkit, cross-bitdepth copying
@@ -275,7 +275,7 @@ namespace ofxCv {
 	ofVec3f toOf(cv::Point3f point);
 	ofRectangle toOf(cv::Rect rect);
 	ofPolyline toOf(cv::RotatedRect rect);
-	template <class T> inline ofPolyline toOf(const vector<cv::Point_<T> >& contour) {
+	template <class T> inline ofPolyline toOf(const std::vector<cv::Point_<T> >& contour) {
 		ofPolyline polyline;
 		polyline.resize(contour.size());
 		for(int i = 0; i < (int)contour.size(); i++) {

--- a/libs/ofxCv/include/ofxCv/Wrappers.h
+++ b/libs/ofxCv/include/ofxCv/Wrappers.h
@@ -40,9 +40,9 @@
 
 namespace ofxCv {
 
-	void loadMat(cv::Mat& mat, string filename);
-	void saveMat(cv::Mat mat, string filename);
-	void saveImage(cv::Mat& mat, string filename, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
+	void loadMat(cv::Mat& mat, std::string filename);
+	void saveMat(cv::Mat mat, std::string filename);
+	void saveImage(cv::Mat& mat, std::string filename, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 
 	// wrapThree are based on functions that operate on three Mat objects.
 	// the first two are inputs, and the third is an output. for example,
@@ -252,7 +252,7 @@ cv::name(xMat, yMat, resultMat);\
 		imitate(dst, src);
 		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		if(srcMat.channels() > 1) {
-			vector<cv::Mat> srcEach, dstEach;
+			std::vector<cv::Mat> srcEach, dstEach;
 			split(srcMat, srcEach);
 			split(dstMat, dstEach);
 			for(int i = 0; i < srcEach.size(); i++) {
@@ -322,11 +322,11 @@ cv::name(xMat, yMat, resultMat);\
 
 	// dst does not imitate src
 	template <class S, class D>
-	void warpPerspective(S& src, D& dst, vector<cv::Point2f>& dstPoints, int flags = cv::INTER_LINEAR) {
+	void warpPerspective(S& src, D& dst, std::vector<cv::Point2f>& dstPoints, int flags = cv::INTER_LINEAR) {
 		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		int w = srcMat.cols;
 		int h = srcMat.rows;
-		vector<cv::Point2f> srcPoints(4);
+		std::vector<cv::Point2f> srcPoints(4);
 		srcPoints[0] = cv::Point2f(0, 0);
 		srcPoints[1] = cv::Point2f(w, 0);
 		srcPoints[2] = cv::Point2f(w, h);
@@ -337,11 +337,11 @@ cv::name(xMat, yMat, resultMat);\
 
 	// dst does not imitate src
 	template <class S, class D>
-	void unwarpPerspective(S& src, D& dst, vector<cv::Point2f>& srcPoints, int flags = cv::INTER_LINEAR) {
+	void unwarpPerspective(S& src, D& dst, std::vector<cv::Point2f>& srcPoints, int flags = cv::INTER_LINEAR) {
 		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		int w = dstMat.cols;
 		int h = dstMat.rows;
-		vector<cv::Point2f> dstPoints(4);
+		std::vector<cv::Point2f> dstPoints(4);
 		dstPoints[0] = cv::Point2f(0, 0);
 		dstPoints[1] = cv::Point2f(w, 0);
 		dstPoints[2] = cv::Point2f(w, h);
@@ -375,15 +375,15 @@ cv::name(xMat, yMat, resultMat);\
 
 	// for contourArea() and arcLength(), see ofPolyline::getArea() and getPerimiter()
 	ofPolyline convexHull(const ofPolyline& polyline);
-	vector<cv::Vec4i> convexityDefects(const vector<cv::Point>& contour);
-	vector<cv::Vec4i> convexityDefects(const ofPolyline& polyline);
+	std::vector<cv::Vec4i> convexityDefects(const std::vector<cv::Point>& contour);
+	std::vector<cv::Vec4i> convexityDefects(const ofPolyline& polyline);
 	cv::RotatedRect minAreaRect(const ofPolyline& polyline);
 	cv::RotatedRect fitEllipse(const ofPolyline& polyline);
 	void fitLine(const ofPolyline& polyline, ofVec2f& point, ofVec2f& direction);
 
 	// kind of obscure function, draws filled polygons on the CPU
 	template <class D>
-	void fillPoly(vector<cv::Point>& points, D& dst) {
+	void fillPoly(std::vector<cv::Point>& points, D& dst) {
 		cv::Mat dstMat = toCv(dst);
 		const cv::Point* ppt[1] = { &(points[0]) };
 		int npt[] = { (int) points.size() };
@@ -439,6 +439,6 @@ cv::name(xMat, yMat, resultMat);\
     }
 
 	// finds the 3x4 matrix that best describes the (premultiplied) affine transformation between two point clouds
-	ofMatrix4x4 estimateAffine3D(vector<ofVec3f>& from, vector<ofVec3f>& to, float accuracy = .99);
-	ofMatrix4x4 estimateAffine3D(vector<ofVec3f>& from, vector<ofVec3f>& to, vector<unsigned char>& outliers, float accuracy = .99);
+	ofMatrix4x4 estimateAffine3D(std::vector<ofVec3f>& from, std::vector<ofVec3f>& to, float accuracy = .99);
+	ofMatrix4x4 estimateAffine3D(std::vector<ofVec3f>& from, std::vector<ofVec3f>& to, std::vector<unsigned char>& outliers, float accuracy = .99);
 }

--- a/libs/ofxCv/include/ofxCv/Wrappers.h
+++ b/libs/ofxCv/include/ofxCv/Wrappers.h
@@ -27,9 +27,10 @@
 
 #pragma once
 
-#include "ofMain.h"
 #include "opencv2/opencv.hpp"
 #include "ofxCv/Utilities.h"
+#include "ofVectorMath.h"
+#include "ofImage.h"
 
 // coherent line drawing
 #include "imatrix.h"

--- a/libs/ofxCv/include/ofxCv/Wrappers.h
+++ b/libs/ofxCv/include/ofxCv/Wrappers.h
@@ -39,11 +39,9 @@
 
 namespace ofxCv {
 
-	using namespace cv;
-
-	void loadMat(Mat& mat, string filename);
-	void saveMat(Mat mat, string filename);
-	void saveImage(Mat& mat, string filename, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
+	void loadMat(cv::Mat& mat, string filename);
+	void saveMat(cv::Mat mat, string filename);
+	void saveImage(cv::Mat& mat, string filename, ofImageQualityType qualityLevel = OF_IMAGE_QUALITY_BEST);
 
 	// wrapThree are based on functions that operate on three Mat objects.
 	// the first two are inputs, and the third is an output. for example,
@@ -59,8 +57,8 @@ template <class X, class Y, class Result>\
 void name(X& x, Y& y, Result& result) {\
 imitate(y, x);\
 imitate(result, x);\
-Mat xMat = toCv(x), yMat = toCv(y);\
-Mat resultMat = toCv(result);\
+cv::Mat xMat = toCv(x), yMat = toCv(y);\
+cv::Mat resultMat = toCv(result);\
 cv::name(xMat, yMat, resultMat);\
 }
 	wrapThree(max);
@@ -76,7 +74,7 @@ cv::name(xMat, yMat, resultMat);\
 
 	// inverting non-floating point images is a just a bitwise not operation
 	template <class S, class D> void invert(S& src, D& dst) {
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		bitwise_not(srcMat, dstMat);
 	}
 
@@ -88,8 +86,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class X, class Y, class R>
 	void lerp(X& x, Y& y, R& result, float amt = .5) {
 		imitate(result, x);
-		Mat xMat = toCv(x), yMat = toCv(y);
-		Mat resultMat = toCv(result);
+		cv::Mat xMat = toCv(x), yMat = toCv(y);
+		cv::Mat resultMat = toCv(result);
 		if(yMat.cols == 0) {
 			copy(x, result);
 		} else if(xMat.cols == 0) {
@@ -103,8 +101,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void normalize(S& src, D& dst) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		cv::normalize(srcMat, dstMat, 0, getMaxVal(getDepth(dst)), NORM_MINMAX);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::normalize(srcMat, dstMat, 0, getMaxVal(getDepth(dst)), cv::NORM_MINMAX);
 	}
 
 	// normalize the min/max to [0, max for this type] in place
@@ -117,8 +115,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void threshold(S& src, D& dst, float thresholdValue, bool invert = false) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		int thresholdType = invert ? THRESH_BINARY_INV : THRESH_BINARY;
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		int thresholdType = invert ? cv::THRESH_BINARY_INV : cv::THRESH_BINARY;
 		float maxVal = getMaxVal(dstMat);
 		cv::threshold(srcMat, dstMat, thresholdValue, maxVal, thresholdType);
 	}
@@ -133,8 +131,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void erode(S& src, D& dst, int iterations = 1) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		cv::erode(srcMat, dstMat, Mat(), cv::Point(-1, -1), iterations);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::erode(srcMat, dstMat, cv::Mat(), cv::Point(-1, -1), iterations);
 	}
 
 	// erode in place
@@ -147,8 +145,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void dilate(S& src, D& dst, int iterations = 1) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		cv::dilate(srcMat, dstMat, Mat(), cv::Point(-1, -1), iterations);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::dilate(srcMat, dstMat, cv::Mat(), cv::Point(-1, -1), iterations);
 	}
 
 	// dilate in place
@@ -161,8 +159,8 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void autothreshold(S& src, D& dst, bool invert = false) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		int flags = THRESH_OTSU | (invert ? THRESH_BINARY_INV : THRESH_BINARY);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		int flags = cv::THRESH_OTSU | (invert ? cv::THRESH_BINARY_INV : cv::THRESH_BINARY);
 		threshold(srcMat, dstMat, 0, 255, flags);
 	}
 
@@ -179,11 +177,11 @@ cv::name(xMat, yMat, resultMat);\
 		// cvtColor allocates Mat for you, but we need this to handle ofImage etc.
 		int targetChannels = getTargetChannelsFromCode(code);
 		imitate(dst, src, getCvImageType(targetChannels, getDepth(src)));
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cvtColor(srcMat, dstMat, code);
 	}
 	// ...or single colors.
-	Vec3b convertColor(Vec3b color, int code);
+	cv::Vec3b convertColor(cv::Vec3b color, int code);
 	ofColor convertColor(ofColor color, int code);
 
     // a common cv task is to convert something to grayscale. this function will
@@ -207,7 +205,7 @@ cv::name(xMat, yMat, resultMat);\
 	void blur(S& src, D& dst, int size) {
 		imitate(dst, src);
 		size = forceOdd(size);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cv::blur(srcMat, dstMat, cv::Size(size, size));
 	}
 
@@ -222,7 +220,7 @@ cv::name(xMat, yMat, resultMat);\
     void GaussianBlur(S& src, D& dst, int size) {
         imitate(dst, src);
         size = forceOdd(size);
-        Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
         cv::GaussianBlur(srcMat, dstMat, cv::Size(size, size), 0, 0);
     }
 
@@ -237,7 +235,7 @@ cv::name(xMat, yMat, resultMat);\
 	void medianBlur(S& src, D& dst, int size) {
 		imitate(dst, src);
 		size = forceOdd(size);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cv::medianBlur(srcMat, dstMat, size);
 	}
 
@@ -251,9 +249,9 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void equalizeHist(S& src, D& dst) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		if(srcMat.channels() > 1) {
-			vector<Mat> srcEach, dstEach;
+			vector<cv::Mat> srcEach, dstEach;
 			split(srcMat, srcEach);
 			split(dstMat, dstEach);
 			for(int i = 0; i < srcEach.size(); i++) {
@@ -276,15 +274,15 @@ cv::name(xMat, yMat, resultMat);\
 	template <class S, class D>
 	void Canny(S& src, D& dst, double threshold1, double threshold2, int apertureSize=3, bool L2gradient=false) {
 		imitate(dst, src, CV_8UC1);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cv::Canny(srcMat, dstMat, threshold1, threshold2, apertureSize, L2gradient);
 	}
 
 	// Sobel edge detection
 	template <class S, class D>
-	void Sobel(S& src, D& dst, int ddepth=-1, int dx=1, int dy=1, int ksize=3, double scale=1, double delta=0, int borderType=BORDER_DEFAULT ) {
+	void Sobel(S& src, D& dst, int ddepth=-1, int dx=1, int dy=1, int ksize=3, double scale=1, double delta=0, int borderType=cv::BORDER_DEFAULT ) {
 		imitate(dst, src, CV_8UC1);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cv::Sobel(srcMat, dstMat, ddepth, dx, dy, ksize, scale, delta, borderType );
 	}
 
@@ -298,7 +296,7 @@ cv::name(xMat, yMat, resultMat);\
 		int width = getWidth(src), height = getHeight(src);
 		imatrix img;
 		img.init(height, width);
-		Mat dstMat = toCv(dst);
+		cv::Mat dstMat = toCv(dst);
 		if(black != 0) {
 			add(dstMat, cv::Scalar(black), dstMat);
 		}
@@ -323,54 +321,54 @@ cv::name(xMat, yMat, resultMat);\
 
 	// dst does not imitate src
 	template <class S, class D>
-	void warpPerspective(S& src, D& dst, vector<Point2f>& dstPoints, int flags = INTER_LINEAR) {
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+	void warpPerspective(S& src, D& dst, vector<cv::Point2f>& dstPoints, int flags = cv::INTER_LINEAR) {
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		int w = srcMat.cols;
 		int h = srcMat.rows;
-		vector<Point2f> srcPoints(4);
-		srcPoints[0] = Point2f(0, 0);
-		srcPoints[1] = Point2f(w, 0);
-		srcPoints[2] = Point2f(w, h);
-		srcPoints[3] = Point2f(0, h);
-		Mat transform = getPerspectiveTransform(&srcPoints[0], &dstPoints[0]);
+		vector<cv::Point2f> srcPoints(4);
+		srcPoints[0] = cv::Point2f(0, 0);
+		srcPoints[1] = cv::Point2f(w, 0);
+		srcPoints[2] = cv::Point2f(w, h);
+		srcPoints[3] = cv::Point2f(0, h);
+		cv::Mat transform = getPerspectiveTransform(&srcPoints[0], &dstPoints[0]);
 		warpPerspective(srcMat, dstMat, transform, dstMat.size(), flags);
 	}
 
 	// dst does not imitate src
 	template <class S, class D>
-	void unwarpPerspective(S& src, D& dst, vector<Point2f>& srcPoints, int flags = INTER_LINEAR) {
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+	void unwarpPerspective(S& src, D& dst, vector<cv::Point2f>& srcPoints, int flags = cv::INTER_LINEAR) {
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		int w = dstMat.cols;
 		int h = dstMat.rows;
-		vector<Point2f> dstPoints(4);
-		dstPoints[0] = Point2f(0, 0);
-		dstPoints[1] = Point2f(w, 0);
-		dstPoints[2] = Point2f(w, h);
-		dstPoints[3] = Point2f(0, h);
-		Mat transform = getPerspectiveTransform(&srcPoints[0], &dstPoints[0]);
+		vector<cv::Point2f> dstPoints(4);
+		dstPoints[0] = cv::Point2f(0, 0);
+		dstPoints[1] = cv::Point2f(w, 0);
+		dstPoints[2] = cv::Point2f(w, h);
+		dstPoints[3] = cv::Point2f(0, h);
+		cv::Mat transform = getPerspectiveTransform(&srcPoints[0], &dstPoints[0]);
 		warpPerspective(srcMat, dstMat, transform, dstMat.size(), flags);
 	}
 
 	// dst does not imitate src
 	template <class S, class D>
-	void warpPerspective(S& src, D& dst, Mat& transform, int flags = INTER_LINEAR) {
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+	void warpPerspective(S& src, D& dst, cv::Mat& transform, int flags = cv::INTER_LINEAR) {
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		warpPerspective(srcMat, dstMat, transform, dstMat.size(), flags);
 	}
 
 	template <class S, class D>
-	void resize(S& src, D& dst, int interpolation = INTER_LINEAR) { // also: INTER_NEAREST, INTER_AREA, INTER_CUBIC, INTER_LANCZOS4
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+	void resize(S& src, D& dst, int interpolation = cv::INTER_LINEAR) { // also: INTER_NEAREST, INTER_AREA, INTER_CUBIC, INTER_LANCZOS4
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		resize(srcMat, dstMat, dstMat.size(), 0, 0, interpolation);
 	}
 
 	template <class S, class D>
-	void resize(S& src, D& dst, float xScale, float yScale, int interpolation = INTER_LINEAR) { // also: INTER_NEAREST, INTER_AREA, INTER_CUBIC, INTER_LANCZOS4
+	void resize(S& src, D& dst, float xScale, float yScale, int interpolation = cv::INTER_LINEAR) { // also: INTER_NEAREST, INTER_AREA, INTER_CUBIC, INTER_LANCZOS4
 		int dstWidth = getWidth(src) * xScale, dstHeight = getHeight(src) * yScale;
 		if(getWidth(dst) != dstWidth || getHeight(dst) != dstHeight) {
 			allocate(dst, dstWidth, dstHeight, getCvImageType(src));
 		}
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		resize(src, dst, interpolation);
 	}
 
@@ -388,33 +386,33 @@ cv::name(xMat, yMat, resultMat);\
 		cv::Mat dstMat = toCv(dst);
 		const cv::Point* ppt[1] = { &(points[0]) };
 		int npt[] = { (int) points.size() };
-		dstMat.setTo(Scalar(0));
-		fillPoly(dstMat, ppt, npt, 1, Scalar(255));
+		dstMat.setTo(cv::Scalar(0));
+		fillPoly(dstMat, ppt, npt, 1, cv::Scalar(255));
 	}
 
 	template <class S, class D>
 	void flip(S& src, D& dst, int code) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		cv::flip(srcMat, dstMat, code);
 	}
 
 	// if you're doing the same rotation multiple times, it's better to precompute
 	// the displacement and use remap.
 	template <class S, class D>
-	void rotate(S& src, D& dst, double angle, ofColor fill = ofColor::black, int interpolation = INTER_LINEAR) {
+	void rotate(S& src, D& dst, double angle, ofColor fill = ofColor::black, int interpolation = cv::INTER_LINEAR) {
 		imitate(dst, src);
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
-		Point2f center(srcMat.cols / 2, srcMat.rows / 2);
-		Mat rotationMatrix = getRotationMatrix2D(center, angle, 1);
-		warpAffine(srcMat, dstMat, rotationMatrix, srcMat.size(), interpolation, BORDER_CONSTANT, toCv(fill));
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Point2f center(srcMat.cols / 2, srcMat.rows / 2);
+		cv::Mat rotationMatrix = getRotationMatrix2D(center, angle, 1);
+		warpAffine(srcMat, dstMat, rotationMatrix, srcMat.size(), interpolation, cv::BORDER_CONSTANT, toCv(fill));
 	}
 
 	// efficient version of rotate that only operates on 0, 90, 180, 270 degrees
 	// the output is allocated to contain all pixels of the input.
 	template <class S, class D>
 	void rotate90(S& src, D& dst, int angle) {
-		Mat srcMat = toCv(src), dstMat = toCv(dst);
+		cv::Mat srcMat = toCv(src), dstMat = toCv(dst);
 		if(angle == 0) {
 			copy(src, dst);
 		} else if(angle == 90) {
@@ -433,9 +431,9 @@ cv::name(xMat, yMat, resultMat);\
 
     template <class S, class D>
     void transpose(S& src, D& dst) {
-        Mat srcMat = toCv(src);
+		cv::Mat srcMat = toCv(src);
         allocate(dst, srcMat.rows, srcMat.cols, srcMat.type());
-        Mat dstMat = toCv(dst);
+		cv::Mat dstMat = toCv(dst);
         cv::transpose(srcMat, dstMat);
     }
 

--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -1,6 +1,8 @@
 #include "ofxCv/Calibration.h"
 #include "ofxCv/Helpers.h"
 #include "ofFileUtils.h"
+#include "ofGraphics.h"
+#include "ofMesh.h"
 
 namespace ofxCv {
     

--- a/libs/ofxCv/src/ContourFinder.cpp
+++ b/libs/ofxCv/src/ContourFinder.cpp
@@ -159,7 +159,11 @@ namespace ofxCv {
 	
 	cv::Point2f ContourFinder::getCentroid(unsigned int i) const {
 		Moments m = moments(contours[i]);
-		return cv::Point2f(m.m10 / m.m00, m.m01 / m.m00);
+		if(m.m00!=0){
+			return cv::Point2f(m.m10 / m.m00, m.m01 / m.m00);
+		}else{
+			return cv::Point2f(0, 0);
+		}
 	}
 	
 	cv::Point2f ContourFinder::getAverage(unsigned int i) const {

--- a/libs/ofxCv/src/ContourFinder.cpp
+++ b/libs/ofxCv/src/ContourFinder.cpp
@@ -1,5 +1,6 @@
 #include "ofxCv/ContourFinder.h"
 #include "ofxCv/Wrappers.h"
+#include "ofGraphics.h"
 
 namespace ofxCv {
 

--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -1,4 +1,5 @@
 #include "ofxCv/Flow.h"
+#include "ofGraphics.h"
 
 namespace ofxCv {
 	

--- a/libs/ofxCv/src/Helpers.cpp
+++ b/libs/ofxCv/src/Helpers.cpp
@@ -1,5 +1,6 @@
 #include "ofxCv/Helpers.h"
 #include "ofxCv/Utilities.h"
+#include "ofGraphics.h"
 
 namespace ofxCv {
 	

--- a/libs/ofxCv/src/Kalman.cpp
+++ b/libs/ofxCv/src/Kalman.cpp
@@ -1,4 +1,4 @@
-#include "Kalman.h"
+#include "ofxCv/Kalman.h"
 
 namespace ofxCv {
 	

--- a/libs/ofxCv/src/ObjectFinder.cpp
+++ b/libs/ofxCv/src/ObjectFinder.cpp
@@ -1,6 +1,8 @@
-#include "ObjectFinder.h"
+#include "ofxCv/ObjectFinder.h"
 
 namespace ofxCv {
+	using namespace cv;
+
 	ObjectFinder::ObjectFinder()
 	:rescale(1)
 	,multiScaleFactor(1.1)

--- a/libs/ofxCv/src/ObjectFinder.cpp
+++ b/libs/ofxCv/src/ObjectFinder.cpp
@@ -1,4 +1,5 @@
 #include "ofxCv/ObjectFinder.h"
+#include "ofGraphics.h"
 
 namespace ofxCv {
 	using namespace cv;


### PR DESCRIPTION
I was having trouble with other library which has a Kalman.h file and Kalman class. This fixes addon_config to have only the necessary includes and not everything recursively.

it also removes 'using namespace cv' and explicitly uses std in headers.