### PR TITLE
added const keyword to draw method of ContourFinder

### DIFF
--- a/libs/ofxCv/include/ofxCv/ContourFinder.h
+++ b/libs/ofxCv/include/ofxCv/ContourFinder.h
@@ -89,7 +89,7 @@ namespace ofxCv {
 		
 		void setSimplify(bool simplify);
 		
-		void draw();
+		void draw() const;
 
 	protected:
 		cv::Mat hsvBuffer, thresh;

--- a/libs/ofxCv/src/ContourFinder.cpp
+++ b/libs/ofxCv/src/ContourFinder.cpp
@@ -285,7 +285,7 @@ namespace ofxCv {
 		this->simplify = simplify;
 	}
 	
-	void ContourFinder::draw() {
+	void ContourFinder::draw() const {
 		ofPushStyle();
 		ofNoFill();
 		for(int i = 0; i < (int)polylines.size(); i++) {


### PR DESCRIPTION
this is needed since of009 ofBaseDraws is more strict and optimised.