### PR TITLE
updated ofVec3f/ofPoint -> glm::vec3 in Flow & Utilities to match OF commit 82ffaca

### DIFF
--- a/example-smile/src/ofApp.h
+++ b/example-smile/src/ofApp.h
@@ -62,7 +62,7 @@ public:
 class LineGraph {
 protected:
     ofMesh mesh;
-    ofVec2f min, max;
+    glm::vec3 min, max;
     int n;
     
 public:
@@ -71,18 +71,18 @@ public:
     }
     void reset() {
         n = 0;
-        min = ofVec2f();
-        max = ofVec2f();
+        min = glm::vec3();
+        max = glm::vec3();
     }
     void add(float y) {
-        ofVec2f cur(n, y);
+        glm::vec3 cur(n, y, 0.0);
         mesh.addVertex(cur);
         if(n == 0) {
             min = cur;
             max = cur;
         } else {
-            min.set(MIN(min.x, cur.x), MIN(min.y, cur.y));
-            max.set(MAX(max.x, cur.x), MAX(max.y, cur.y));
+            min = {MIN(min.x, cur.x), MIN(min.y, cur.y), 0.0};
+            max = {MAX(max.x, cur.x), MAX(max.y, cur.y), 0.0};
         }
         n++;
     }

--- a/libs/ofxCv/include/ofxCv/Flow.h
+++ b/libs/ofxCv/include/ofxCv/Flow.h
@@ -73,13 +73,13 @@ namespace ofxCv {
 		void setPyramidLevels(int levels);
 		
 		//returns tracking features for this image
-		std::vector<ofPoint> getFeatures();
-		std::vector<ofPoint> getCurrent();
-		std::vector<ofVec2f> getMotion();
+		std::vector<glm::vec3> getFeatures(); // changed from ofpoint to vec3 as expected ...
+		std::vector<glm::vec2> getCurrent(); // changed from ofpoint to vec2 (not vec3) ???
+		std::vector<glm::vec2> getMotion();
 		
 		// recalculates features to track
 		void resetFeaturesToTrack();
-		void setFeaturesToTrack(const std::vector<ofVec2f> & features);
+		void setFeaturesToTrack(const std::vector<glm::vec2> & features);
 		void setFeaturesToTrack(const std::vector<cv::Point2f> & features);
         void resetFlow();
 	protected:
@@ -129,12 +129,12 @@ namespace ofxCv {
 		void setUseGaussian(bool gaussian);
 		
 		cv::Mat& getFlow();
-		ofVec2f getTotalFlow();
-		ofVec2f getAverageFlow();		
-		ofVec2f getFlowOffset(int x, int y);
-		ofVec2f getFlowPosition(int x, int y);
-		ofVec2f getTotalFlowInRegion(ofRectangle region);
-		ofVec2f getAverageFlowInRegion(ofRectangle region);
+		glm::vec2 getTotalFlow();
+		glm::vec2 getAverageFlow();		
+		glm::vec2 getFlowOffset(int x, int y);
+		glm::vec2 getFlowPosition(int x, int y);
+		glm::vec2 getTotalFlowInRegion(ofRectangle region);
+		glm::vec2 getAverageFlowInRegion(ofRectangle region);
 		
         //call this if you switch to a new video file to reset internal caches
         void resetFlow();

--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -239,12 +239,12 @@ namespace ofxCv {
 		return toCv(img.getPixels());
 	}
 	cv::Mat toCv(ofMesh& mesh);
-	cv::Point2f toCv(ofVec2f vec);
-	cv::Point3f toCv(ofVec3f vec);
+	cv::Point2f toCv(glm::vec2 vec);
+	cv::Point3f toCv(glm::vec3 vec);
 	cv::Rect toCv(ofRectangle rect);
 	std::vector<cv::Point2f> toCv(const ofPolyline& polyline);
-	std::vector<cv::Point2f> toCv(const std::vector<ofVec2f>& points);
-	std::vector<cv::Point3f> toCv(const std::vector<ofVec3f>& points);
+	std::vector<cv::Point2f> toCv(const std::vector<glm::vec2>& points);
+	std::vector<cv::Point3f> toCv(const std::vector<glm::vec3>& points);
 	cv::Scalar toCv(ofColor color);
 	
 	// cross-toolkit, cross-bitdepth copying
@@ -275,8 +275,8 @@ namespace ofxCv {
 	}
 	
 	// toOf functions
-	ofVec2f toOf(cv::Point2f point);
-	ofVec3f toOf(cv::Point3f point);
+	glm::vec2 toOf(cv::Point2f point);
+	glm::vec3 toOf(cv::Point3f point);
 	ofRectangle toOf(cv::Rect rect);
 	ofPolyline toOf(cv::RotatedRect rect);
 	template <class T> inline ofPolyline toOf(const std::vector<cv::Point_<T> >& contour) {

--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -152,7 +152,7 @@ namespace ofxCv {
 		calcFeaturesNextFrame=true;
 	}
 	
-	void FlowPyrLK::setFeaturesToTrack(const vector<ofVec2f> & features){
+	void FlowPyrLK::setFeaturesToTrack(const vector<glm::vec2> & features){
 		nextPts.resize(features.size());
 		for(int i=0;i<(int)features.size();i++){
 			nextPts[i]=toCv(features[i]);
@@ -165,13 +165,13 @@ namespace ofxCv {
 		calcFeaturesNextFrame = false;
 	}
 	
-	vector<ofPoint> FlowPyrLK::getFeatures(){
-		ofPolyline poly =toOf(prevPts);
+	vector<glm::vec3> FlowPyrLK::getFeatures(){ // changed from ofpoint to vec3 as expected ...
+		ofPolyline poly = toOf(prevPts);
 		return poly.getVertices();
 	}
 	
-	vector<ofPoint> FlowPyrLK::getCurrent(){
-		vector<ofPoint> ret;
+	vector<glm::vec2> FlowPyrLK::getCurrent(){ // changed from ofpoint to vec2 (not vec3) ???
+		vector<glm::vec2> ret; // changed from ofpoint to vec2 (not vec3) ???
 		for(int i = 0; i < (int)nextPts.size(); i++) {
 			if(status[i]){
 				ret.push_back(toOf(nextPts[i]));
@@ -180,8 +180,8 @@ namespace ofxCv {
 		return ret;
 	}
 	
-	vector<ofVec2f> FlowPyrLK::getMotion(){
-		vector<ofVec2f> ret;
+	vector<glm::vec2> FlowPyrLK::getMotion(){
+		vector<glm::vec2> ret;
 		for(int i = 0; i < (int)prevPts.size(); i++) {
 			if(status[i]){
 				ret.push_back(toOf(nextPts[i])-toOf(prevPts[i]));
@@ -191,8 +191,8 @@ namespace ofxCv {
 	}
 	
 	void FlowPyrLK::drawFlow(ofRectangle rect) {
-		ofVec2f offset(rect.x,rect.y);
-		ofVec2f scale(rect.width/getWidth(),rect.height/getHeight());
+		glm::vec2 offset(rect.x,rect.y);
+		glm::vec2 scale(rect.width/getWidth(),rect.height/getHeight());
 		for(int i = 0; i < (int)prevPts.size(); i++) {
 			if(status[i]){
 				ofDrawLine(toOf(prevPts[i])*scale+offset, toOf(nextPts[i])*scale+offset);
@@ -277,50 +277,50 @@ namespace ofxCv {
         }
         return flow;
     }
-	ofVec2f FlowFarneback::getFlowOffset(int x, int y){
+	glm::vec2 FlowFarneback::getFlowOffset(int x, int y){
 		if(!hasFlow){
-			return ofVec2f(0, 0);
+			return glm::vec2(0, 0);
 		}
 		const Vec2f& vec = flow.at<Vec2f>(y, x);
-		return ofVec2f(vec[0], vec[1]);
+		return glm::vec2(vec[0], vec[1]);
 	}
-	ofVec2f FlowFarneback::getFlowPosition(int x, int y){
+	glm::vec2 FlowFarneback::getFlowPosition(int x, int y){
 		if(!hasFlow){
-			return ofVec2f(0, 0);
+			return glm::vec2(0, 0);
 		}
 		const Vec2f& vec = flow.at<Vec2f>(y, x);
-		return ofVec2f(x + vec[0], y + vec[1]);
+		return glm::vec2(x + vec[0], y + vec[1]);
 	}
-	ofVec2f FlowFarneback::getTotalFlow(){
+	glm::vec2 FlowFarneback::getTotalFlow(){
 		return getTotalFlowInRegion(ofRectangle(0,0,flow.cols, flow.rows));
 	}
-	ofVec2f FlowFarneback::getAverageFlow(){
+	glm::vec2 FlowFarneback::getAverageFlow(){
 		return getAverageFlowInRegion(ofRectangle(0,0,flow.cols,flow.rows));
 	}
 	
-	ofVec2f FlowFarneback::getAverageFlowInRegion(ofRectangle rect){
+	glm::vec2 FlowFarneback::getAverageFlowInRegion(ofRectangle rect){
 		return getTotalFlowInRegion(rect)/(rect.width*rect.height);
 	}
 	
-	ofVec2f FlowFarneback::getTotalFlowInRegion(ofRectangle region){
+	glm::vec2 FlowFarneback::getTotalFlowInRegion(ofRectangle region){
 		if(!hasFlow){
-			return ofVec2f(0, 0);
+			return glm::vec2(0, 0);
 		}
 		
 		const Scalar& sc = sum(flow(toCv(region)));
-		return ofVec2f(sc[0], sc[1]);
+		return glm::vec2(sc[0], sc[1]);
 	}
 	
 	void FlowFarneback::drawFlow(ofRectangle rect){
 		if(!hasFlow){
 			return;
 		}
-		ofVec2f offset(rect.x,rect.y);
-		ofVec2f scale(rect.width/flow.cols, rect.height/flow.rows);
+		glm::vec2 offset(rect.x,rect.y);
+		glm::vec2 scale(rect.width/flow.cols, rect.height/flow.rows);
 		int stepSize = 4; //TODO: make class-level parameteric
 		for(int y = 0; y < flow.rows; y += stepSize) {
 			for(int x = 0; x < flow.cols; x += stepSize) {
-				ofVec2f cur = ofVec2f(x, y) * scale + offset;
+				glm::vec2 cur = glm::vec2(x, y) * scale + offset;
 				ofDrawLine(cur, getFlowPosition(x, y) * scale + offset);
 			}
 		}

--- a/libs/ofxCv/src/Utilities.cpp
+++ b/libs/ofxCv/src/Utilities.cpp
@@ -15,11 +15,11 @@ namespace ofxCv {
 		return mat;
 	}
 	
-	Point2f toCv(ofVec2f vec) {
+	Point2f toCv(glm::vec2 vec) {
 		return Point2f(vec.x, vec.y);
 	}
 	
-	Point3f toCv(ofVec3f vec) {
+	Point3f toCv(glm::vec3 vec) {
 		return Point3f(vec.x, vec.y, vec.z);
 	}
 	
@@ -28,7 +28,7 @@ namespace ofxCv {
 	}
 	
 	Mat toCv(ofMesh& mesh) {
-		vector<ofVec3f>& vertices = mesh.getVertices();
+		vector<glm::vec3>& vertices = mesh.getVertices();
 		return Mat(1, vertices.size(), CV_32FC3, &vertices[0]);
 	}
 	
@@ -42,7 +42,7 @@ namespace ofxCv {
 		return contour;		
 	}
 	
-	vector<cv::Point2f> toCv(const vector<ofVec2f>& points) {
+	vector<cv::Point2f> toCv(const vector<glm::vec2>& points) {
 		vector<cv::Point2f> out(points.size());
 		for(int i = 0; i < points.size(); i++) {
 			out[i].x = points[i].x;
@@ -51,7 +51,7 @@ namespace ofxCv {
 		return out;		
 	}
 	
-	vector<cv::Point3f> toCv(const vector<ofVec3f>& points) {
+	vector<cv::Point3f> toCv(const vector<glm::vec3>& points) {
 		vector<cv::Point3f> out(points.size());
 		for(int i = 0; i < points.size(); i++) {
 			out[i].x = points[i].x;
@@ -65,12 +65,12 @@ namespace ofxCv {
 		return Scalar(color.r, color.g, color.b, color.a);
 	}
 	
-	ofVec2f toOf(Point2f point) {
-		return ofVec2f(point.x, point.y);
+	glm::vec2 toOf(Point2f point) {
+		return glm::vec2(point.x, point.y);
 	}
 	
-	ofVec3f toOf(Point3f point) {
-		return ofVec3f(point.x, point.y, point.z);
+	glm::vec3 toOf(Point3f point) {
+		return glm::vec3(point.x, point.y, point.z);
 	}
 	
 	ofRectangle toOf(cv::Rect rect) {


### PR DESCRIPTION
in response to issue https://github.com/kylemcdonald/ofxCv/issues/196 ->

updated references to ofPoint, ofVec2f and ofVec3f in Flow & Utilities to match the new openframeworks conventions established in this commit from feb 2016: https://github.com/openframeworks/openFrameworks/commit/82ffacaa5e965433834062d2f52e44b282901aba

unexpectedly, std::vector<ofPoint> Flow::getCurrent() seems to want to be std::vector<glm::vec2> Flow::getCurrent() now (instead of glm::vec3) ???

but facetracking examples compile & run (against of main branch) now! ;)