### PR TITLE
fix https://github.com/kylemcdonald/ofxCv/issues/202

### DIFF
--- a/libs/ofxCv/src/ContourFinder.cpp
+++ b/libs/ofxCv/src/ContourFinder.cpp
@@ -87,18 +87,19 @@ namespace ofxCv {
                     curArea = -curArea;
                     hole = false;
                 }
-                allHoles.push_back(hole);
-				allAreas.push_back(curArea);
+
 				if((!needMinFilter || curArea >= imgMinArea) &&
 					 (!needMaxFilter || curArea <= imgMaxArea)) {
 					allIndices.push_back(i);
+                    allHoles.push_back(hole);
+                    allAreas.push_back(curArea);
 				}
 			}
 		} else {
 			for(size_t i = 0; i < allContours.size(); i++) {
-				if (sortBySize) {
-					allAreas.push_back(contourArea(allContours[i]));
-				}
+                double curArea = contourArea(Mat(allContours[i]), true);
+                allAreas.push_back(abs(curArea));
+                allHoles.push_back(curArea > 0);
 				allIndices.push_back(i);
 			}
 		}


### PR DESCRIPTION
now `allAreas`, `allHoles` and `allIndices` should have the same size
I hope it is enough to fix https://github.com/kylemcdonald/ofxCv/issues/202