### PR TITLE
Fix for issue #175 - yml parser was not writing features correctly

### DIFF
--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -125,7 +125,7 @@ namespace ofxCv {
         fs << "reprojectionError" << reprojectionError;
         fs << "features" << "[";
         for(std::size_t i = 0; i < imagePoints.size(); i++) {
-            fs << "[:" << imagePoints[i] << "]";
+            fs << imagePoints[i];
         }
         fs << "]";
     }


### PR DESCRIPTION
Fixing issue #175.

Changed the calibration save method to correctly export the vector of vector of points (otherwise it crashes when we try to reload it).