### PR TITLE
ContourFinder: Fixed out of bounds vector access.

### DIFF
--- a/libs/ofxCv/src/ContourFinder.cpp
+++ b/libs/ofxCv/src/ContourFinder.cpp
@@ -114,11 +114,12 @@ namespace ofxCv {
 		polylines.clear();
         boundingRects.clear();
         holes.clear();
+
 		for(size_t i = 0; i < allIndices.size(); i++) {
 			contours.push_back(allContours[allIndices[i]]);
-			polylines.push_back(toOf(contours[i]));
-			boundingRects.push_back(boundingRect(contours[i]));
-            holes.push_back(allHoles[allIndices[i]]);
+			polylines.push_back(toOf(contours.back()));
+			boundingRects.push_back(boundingRect(contours.back()));
+            holes.push_back(allHoles[i]);
 		}
 		
 		// track bounding boxes


### PR DESCRIPTION
**Problem**
` holes.push_back(allHoles[allIndices[i]]);`
The `allIndices` vectors holds indices of the `allContours` vector. If some of the contours are being filtered out it will mean that `allHoles` vector size will be less than `allContours` size; hence trying `allHoles[allIndices[i]` will possibly go out of bounds.
**Fix**
As the elements of `allIndices` and `allHoles` are always added "together", their indices are related.
so  `holes.push_back(allHoles[i]);` fixes this.