### PR TITLE
Not returning false if void is expected.

### DIFF
--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -402,7 +402,7 @@ namespace ofxCv {
     void Calibration::undistort(Mat img, int interpolationMode) {
         if(img.rows != undistortMapX.rows || img.cols != undistortMapX.cols){
             ofLog(OF_LOG_ERROR, "undistort() Input image and undistort map not same size");
-            return false;
+            return;
         }
         
         img.copyTo(undistortBuffer);


### PR DESCRIPTION
ofxCV fails to compile using the current OF-nightly (v20170714) on Linux via makefile.

```
openFrameworks/addons/ofxCv/libs/ofxCv/src/Calibration.cpp:405:20: error: return-statement with a value, in function returning 'void' [-fpermissive]
             return false;
                    ^~~~~
```