### PR TITLE
Correction to saving/loading in Calibration.cpp

### DIFF
--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -124,7 +124,7 @@ namespace ofxCv {
         fs << "reprojectionError" << reprojectionError;
         fs << "features" << "[";
         for(int i = 0; i < (int)imagePoints.size(); i++) {
-            fs << "[:" << imagePoints[i] << "]";
+            fs << imagePoints[i];
         }
         fs << "]";
     }


### PR DESCRIPTION
Line 127 in Calibration.save() appears to cause errors (owing to the introduction of superfluous brackets) when an attempt to load the saved file is later made. I corrected the problem by changing 
fs << "[:" << imagePoints[i] << "]";  // previous code
to
fs << imagePoints[i]; // new code