### PR TITLE
Removed applyMatrix in favour of ofMultMatrix

### DIFF
--- a/example-ar/src/ofApp.cpp
+++ b/example-ar/src/ofApp.cpp
@@ -35,7 +35,7 @@ void ofApp::draw() {
 	cam.draw(0, 0);
 	if(found) {
 		calibration.getDistortedIntrinsics().loadProjectionMatrix();
-		applyMatrix(modelMatrix);
+		ofMultMatrix(modelMatrix);
 		
 		ofMesh mesh;
 		mesh.setMode(OF_PRIMITIVE_POINTS);

--- a/libs/ofxCv/include/ofxCv/Helpers.h
+++ b/libs/ofxCv/include/ofxCv/Helpers.h
@@ -16,7 +16,6 @@
 namespace ofxCv {
 	
 	ofMatrix4x4 makeMatrix(cv::Mat rotation, cv::Mat translation);
-	void applyMatrix(const ofMatrix4x4& matrix);
 	
 	void drawMat(const cv::Mat& mat, float x, float y);
 	void drawMat(const cv::Mat& mat, float x, float y, float width, float height);

--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -526,7 +526,7 @@ namespace ofxCv {
         ofPushMatrix();
         ofNoFill();
         
-        applyMatrix(makeMatrix(boardRotations[i], boardTranslations[i]));
+        ofMultMatrix(makeMatrix(boardRotations[i], boardTranslations[i]));
         
         ofSetColor(ofColor::fromHsb(255 * i / size(), 255, 255));
         

--- a/libs/ofxCv/src/Helpers.cpp
+++ b/libs/ofxCv/src/Helpers.cpp
@@ -45,10 +45,6 @@ namespace ofxCv {
 		tex.draw(x, y, width, height);
 	}
 	
-	void applyMatrix(const ofMatrix4x4& matrix) {
-		glMultMatrixf((GLfloat*) matrix.getPtr());
-	}
-	
 	int forceOdd(int x) {
 		return (x / 2) * 2 + 1;
 	}


### PR DESCRIPTION
ofxCv::applyMatrix does not work with programmable renderer.  `glMultMatrixf` assumes fixed pipeline and won't pass the matrix to the shader.

I've removed this helper and updated the code to use `ofMultMatrix` instead.