### PR TITLE
Copy the TrackedObject index in the copy constructor.

### DIFF
--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -79,7 +79,7 @@ namespace ofxCv {
 		:lastSeen(old.lastSeen)
 		,label(old.label)
 		,age(old.age)
-		,index(-1)
+		,index(old.index)
 		,object(old.object){
 		}
 		void timeStep(bool visible) {
@@ -117,7 +117,7 @@ namespace ofxCv {
 		std::map<unsigned int, TrackedObject<T>*> previousLabelMap, currentLabelMap;
 		
 		unsigned int persistence;
-    	        unsigned long long curLabel;
+		unsigned long long curLabel;
 		float maximumDistance;
 		unsigned long long getNewLabel() {
 			curLabel++;


### PR DESCRIPTION
This is necessary otherwise the index gets lost when copying `TrackedObject` into an `std::vector`, as is being done [here](https://github.com/kylemcdonald/ofxCv/blob/master/libs/ofxCv/include/ofxCv/Tracker.h#L203) and [here](https://github.com/kylemcdonald/ofxCv/blob/master/libs/ofxCv/include/ofxCv/Tracker.h#L215). 