### PR TITLE
Changing ofVec2f to ofVec3f

### DIFF
--- a/example-contours-following/src/ofApp.h
+++ b/example-contours-following/src/ofApp.h
@@ -6,7 +6,7 @@
 class Glow : public ofxCv::RectFollower {
 protected:
 	ofColor color;
-	ofVec2f cur, smooth;
+	ofVec3f cur, smooth;
 	float startedDying;
 	ofPolyline all;
 public:


### PR DESCRIPTION
In oF V10.0 this project does not seem to compile, because the addVertex() method is expecting a ofVec3f instead of a ofVec2f