### PR TITLE
fix getMotion() function in PyrLK optical flow

### DIFF
--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -181,7 +181,7 @@ namespace ofxCv {
 	}
     
 	std::vector<glm::vec2> FlowPyrLK::getMotion(){
-		std::vector<glm::vec2> ret(prevPts.size());
+		std::vector<glm::vec2> ret;
 		for(std::size_t i = 0; i < prevPts.size(); i++) {
 			if(status[i]){
 				ret.push_back(toOf(nextPts[i])-toOf(prevPts[i]));

--- a/libs/ofxCv/src/Flow.cpp
+++ b/libs/ofxCv/src/Flow.cpp
@@ -101,12 +101,16 @@ namespace ofxCv {
 		if(!nextPts.empty() || calcFeaturesNextFrame){
 			if(calcFeaturesNextFrame){
 				calcFeaturesToTrack(prevPts, next);
+				if (prevPts.empty()) {
+					nextPts.clear();
+					return;
+				}
 				calcFeaturesNextFrame = false;
 			}else{
                 swap(prevPts, nextPts);
 			}
 			nextPts.clear();
-            
+
 #if CV_MAJOR_VERSION>=2 && (CV_MINOR_VERSION>4 || (CV_MINOR_VERSION==4 && CV_SUBMINOR_VERSION>=1))
 			if (prevPyramid.empty()) {
 				buildOpticalFlowPyramid(prev,prevPyramid,cv::Size(windowSize, windowSize),10);


### PR DESCRIPTION
without this fix getMotion() returns double the size of prevPts. push_back adds on top of the empty elements allocated in the constructor.