### PR TITLE
Added missing includes so it is compatible with openCv4

### DIFF
--- a/libs/ofxCv/include/ofxCv/Utilities.h
+++ b/libs/ofxCv/include/ofxCv/Utilities.h
@@ -18,7 +18,8 @@
 #include "ofVideoGrabber.h"
 #include "ofPolyline.h"
 #include "ofVectorMath.h"
-
+#include "opencv2/imgproc/imgproc_c.h"
+#include "opencv2/calib3d/calib3d_c.h"
 namespace ofxCv {
 	// these functions are for accessing Mat, ofPixels and ofImage consistently.
 	// they're very important for imitate().


### PR DESCRIPTION
Just a small fix so it can compile and run with OF's current master branch.
The added includes are for the C types. Shouldn't we change all of ofxCv to use the C++ types? 
