### PR TITLE
add alternative thinning method (skeletonize)

### DIFF
--- a/libs/ofxCv/include/ofxCv/Helpers.h
+++ b/libs/ofxCv/include/ofxCv/Helpers.h
@@ -193,6 +193,30 @@ namespace ofxCv {
 		for(int i=0;i<n;i++){int j=q[i];if(!p[j+ic2]&&!p[j+ic1]&&!p[j+ib1]&&p[j+ia2]&&p[j+ib3]){p[j]=0;}}
 		for(int i=0;i<n;i++){int j=q[i];if(!p[j+ib1]&&!p[j+ia1]&&!p[j+ia2]&&p[j+ic2]&&p[j+ib3]){p[j]=0;}}
 	}
+
+	//same as above, different implementation taken from
+	//http://felix.abecassis.me/2011/09/opencv-morphological-skeleton/
+	template <class T>
+	void thin2(T& img) {
+
+		cv::Mat mat = toCv(img);
+		cv::Mat skel(mat.size(), CV_8UC1, cv::Scalar(0));
+		cv::Mat temp;
+		cv::Mat eroded;
+
+		cv::Mat element = cv::getStructuringElement(cv::MORPH_CROSS, cv::Size(3, 3));
+		bool done;
+		do{
+			cv::erode(mat, eroded, element);
+			cv::dilate(eroded, temp, element);
+			cv::subtract(mat, temp, temp);
+			cv::bitwise_or(skel, temp, skel);
+			eroded.copyTo(mat);
+			done = (cv::countNonZero(mat) == 0);
+		} while (!done);
+		skel.copyTo(mat);
+		return;
+	}
 	
 	// given a vector of lines, this function will find the average angle
 	float weightedAverageAngle(const std::vector<cv::Vec4i>& lines);


### PR DESCRIPTION
This adds alternative thin (skeletonize) implementation to the library.

The provided thin() doesn't always result the results I was expecting. For example, given this input:

![Screen Shot 2019-04-17 at 17 17 07](https://user-images.githubusercontent.com/167057/56299678-cdc5d980-6134-11e9-84ff-141abf8f23aa.png)

The original thin() gets you this:

![Screen Shot 2019-04-17 at 17 16 37](https://user-images.githubusercontent.com/167057/56299720-de764f80-6134-11e9-8840-c5d7844903ff.png)

This new alternative implementation thin2() gets you this:

![Screen Shot 2019-04-17 at 17 16 49](https://user-images.githubusercontent.com/167057/56299747-ee8e2f00-6134-11e9-8bda-e254da75fbf6.png)

The implementation comes from here http://felix.abecassis.me/2011/09/opencv-morphological-skeleton/.