### PR TITLE
k-means wrapper for unsupervised color clustering

### DIFF
--- a/libs/ofxCv/include/ofxCv/Wrappers.h
+++ b/libs/ofxCv/include/ofxCv/Wrappers.h
@@ -173,6 +173,47 @@ cv::name(xMat, yMat, resultMat);\
 		ofxCv::autothreshold(srcDst, srcDst, invert);
 	}
 
+    // k-means color clustering (high computational cost, not intended for real-time operation)
+    template <class S, class D>
+    cv::Mat kmeans(const S& src, D& dst, int nClusters, int maxIterations = 10, double eps = 0.1, int attempts = 3) {
+        cv::Mat srcMat = toCv(src);
+        if (srcMat.type() != CV_8UC1 && srcMat.type() != CV_8UC3) {
+            ofLogError("ofxCV") << "Unsupported image type in kmeans";
+            return cv::Mat();
+        }
+        cv::Mat labels, centers;
+        cv::Mat samples(srcMat.rows * srcMat.cols, 1, CV_32F);
+        for(int y = 0; y < srcMat.rows; ++y)
+            for(int x = 0; x < srcMat.cols; ++x)
+                if(srcMat.channels() == 3) {
+                    samples.at<float>(x + y * srcMat.cols, 0) = srcMat.at<cv::Vec3b>(y,x)[0];
+                    samples.at<float>(x + y * srcMat.cols, 1) = srcMat.at<cv::Vec3b>(y,x)[1];
+                    samples.at<float>(x + y * srcMat.cols, 2) = srcMat.at<cv::Vec3b>(y,x)[2];
+                } else samples.at<float>(x + y * srcMat.cols) = srcMat.at<uchar>(y,x);
+        
+        double compactness = cv::kmeans(samples, nClusters, labels,
+                        cv::TermCriteria( cv::TermCriteria::EPS+cv::TermCriteria::COUNT, maxIterations, eps),
+                        attempts, cv::KmeansFlags::KMEANS_PP_CENTERS, centers);
+
+        cv::Mat dstMat(srcMat.size(), srcMat.type());
+        for(int y = 0; y < srcMat.rows; ++y)
+            for(int x = 0; x < srcMat.cols; ++x) {
+                int clusterID = labels.at<int>(x + y * srcMat.cols, 0);
+                if(srcMat.channels() == 3) {
+                    dstMat.at<cv::Vec3b>(y,x)[0] = centers.at<float>(clusterID, 0);
+                    dstMat.at<cv::Vec3b>(y,x)[1] = centers.at<float>(clusterID, 1);
+                    dstMat.at<cv::Vec3b>(y,x)[2] = centers.at<float>(clusterID, 2);
+                } else dstMat.at<uchar>(y,x) = centers.at<uchar>(clusterID);
+            }
+
+        ofxCv::toOf(dstMat, dst);
+        // Returning centers as Mat. Access the class centroids by using
+        // centers.at<uchar>(k) for grayscale images,
+        // centers.at<Vec3b>(k) for 3-channel color images or
+        // centers.at<float>(k, channel) for a specific color component.
+        return centers;
+    }
+
 	// CV_RGB2GRAY, CV_HSV2RGB, etc. with [RGB, BGR, GRAY, HSV, HLS, XYZ, YCrCb, Lab, Luv]
 	// you can convert whole images...
 	template <class S, class D>


### PR DESCRIPTION
Wrapping k-means...

I don't know why the opencv's k-means implementation returns properly classified segments, but the cluster centroids look odd. In this [example](https://github.com/valillon/DepthParallaxPainter) I had to ignored the opencv centroids and recalculating them in a different way.

Two clustering samples of color and grayscale clustering created with this commit on a RGB image and its depth-map, respectively.

![meninas_kmeans_small](https://user-images.githubusercontent.com/2164412/78977206-09ad3800-7b18-11ea-829d-afdb5a354ea7.jpg)

