### PR TITLE
fix calibration undistort for points

### DIFF
--- a/libs/ofxCv/include/ofxCv/Tracker.h
+++ b/libs/ofxCv/include/ofxCv/Tracker.h
@@ -125,7 +125,7 @@ namespace ofxCv {
 		}
 		
 	public:
-		Tracker<T>()
+		Tracker()
 		:persistence(15)
 		,curLabel(0)
 		,maximumDistance(64) {

--- a/libs/ofxCv/src/Calibration.cpp
+++ b/libs/ofxCv/src/Calibration.cpp
@@ -417,6 +417,8 @@ namespace ofxCv {
         cv::Mat matSrc = cv::Mat(1, 1, CV_32FC2, &src.x);
         cv::Mat matDst = cv::Mat(1, 1, CV_32FC2, &dst.x);;
         undistortPoints(matSrc, matDst, distortedIntrinsics.getCameraMatrix(), distCoeffs);
+        dst.x = dst.x * undistortedIntrinsics.getCameraMatrix().at<double>(0, 0) + undistortedIntrinsics.getCameraMatrix().at<double>(0, 2);
+        dst.y = dst.y * undistortedIntrinsics.getCameraMatrix().at<double>(1, 1) + undistortedIntrinsics.getCameraMatrix().at<double>(1, 2);
         return dst;
     }
     
@@ -426,6 +428,10 @@ namespace ofxCv {
         cv::Mat matSrc = cv::Mat(n, 1, CV_32FC2, &src[0].x);
         cv::Mat matDst = cv::Mat(n, 1, CV_32FC2, &dst[0].x);
         undistortPoints(matSrc, matDst, distortedIntrinsics.getCameraMatrix(), distCoeffs);
+        for (auto& v : dst) {
+            v.x = v.x * undistortedIntrinsics.getCameraMatrix().at<double>(0, 0) + undistortedIntrinsics.getCameraMatrix().at<double>(0, 2);
+            v.y = v.y * undistortedIntrinsics.getCameraMatrix().at<double>(1, 1) + undistortedIntrinsics.getCameraMatrix().at<double>(1, 2);
+        }
     }
     
     bool Calibration::getTransformation(Calibration& dst, cv::Mat& rotation, cv::Mat& translation) {


### PR DESCRIPTION
The undistort function for points returned values in -1 to 1 range that didn't match up with the results of the undistort function for images. This request applies the correct camera matrix so that points are returned in pixel coordinates.