### PR TITLE
Fix crash in example-flow-distort-shader due to type mismatch

### DIFF
--- a/example-flow-distort-shader/src/MotionAmplifier.h
+++ b/example-flow-distort-shader/src/MotionAmplifier.h
@@ -65,7 +65,7 @@ public:
 		flow.calcOpticalFlow(rescaled);
         duplicateFirstChannel(flow.getFlow(), flow3);
         flow3 *= scaleFactor;
-        flow3 += cv::Scalar_<float>(.5, .5, 0);
+        flow3 += cv::Scalar(.5, .5, 0);
         ofxCv::blur(flow3, blurAmount);
         int w = flow3.cols, h = flow3.rows;
         if(needToReset || accumulator.size() != flow3.size()) {


### PR DESCRIPTION
# Description
Fixed a crash caused by type mismatch of cv::Scalar in the example-flow-distort-shader sample.